### PR TITLE
Adding new BlackParrot tile to OpenPiton

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	url = https://github.com/PrincetonUniversity/openpiton-aws.git
 [submodule "piton/design/chip/tile/blackparrot"]
 	path = piton/design/chip/tile/blackparrot
-	url = https://github.com/black-parrot/pre-alpha-release.git
-	branch = top_dev_project_hierarcoherent
+	url = https://github.com/black-parrot/black-parrot.git
+	branch = parrotpiton

--- a/piton/design/chip/rtl/chip.v.pyv
+++ b/piton/design/chip/rtl/chip.v.pyv
@@ -1109,18 +1109,21 @@ module chip(
             currenttile = currenttile.replace("COREIDY", "8'd" + repr(j));
             currenttile = currenttile.replace("out_", "tile_%d_%d_out_" % (j,i));
             currenttile = currenttile.replace("_FLAT_ID_", repr(flatid));
+            currenttype = "`SPARC_TILE"
 
             if (PITON_PICO_HET):
                 if (flatid % 2) == 0:
-                    currenttile = currenttile.replace("TYPE_OF_TILE", "`SPARC_TILE")
+                    currenttype = "`SPARC_TILE"
                 else:
-                    currenttile = currenttile.replace("TYPE_OF_TILE", "`PICORV32_TILE")
+                    currenttype = "`PICORV32_TILE"
             elif (PITON_PICO):
-                currenttile = currenttile.replace("TYPE_OF_TILE", "`PICORV32_TILE")
+                currenttype = "`PICORV32_TILE"
             elif (PITON_ARIANE):
-                currenttile = currenttile.replace("TYPE_OF_TILE", "`ARIANE_RV64_TILE")
+                currenttype = "`ARIANE_RV64_TILE"
             else:
-                currenttile = currenttile.replace("TYPE_OF_TILE", "`SPARC_TILE")
+                currenttype = "`SPARC_TILE"
+
+            currenttile = currenttile.replace("TYPE_OF_TILE", currenttype)
 
             if (NETWORK_CONFIG == "xbar_config"):
                 currenttile = currenttile.replace("in_", "xbar_%d_out_" % i);

--- a/piton/design/chip/rtl/chip.v.pyv
+++ b/piton/design/chip/rtl/chip.v.pyv
@@ -1118,6 +1118,8 @@ module chip(
                     currenttype = "`PICORV32_TILE"
             elif (PITON_PICO):
                 currenttype = "`PICORV32_TILE"
+            elif (PITON_BLACKPARROT):
+                currenttype = "`BLACKPARROT_TILE"
             elif (PITON_ARIANE):
                 currenttype = "`ARIANE_RV64_TILE"
             else:

--- a/piton/design/chip/tile/l15/rtl/Flist.l15
+++ b/piton/design/chip/tile/l15/rtl/Flist.l15
@@ -54,5 +54,3 @@ sram_wrappers/sram_l15_hmt.v
 
 pico_decoder.v
 l15_picoencoder.v
-
-bp_l15_transducer.v

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -829,36 +829,44 @@ if (TILE_TYPE == `BLACKPARROT_TILE) begin : g_blackparrot_core
     //////////////////////
     bp_piton_top
       proc
-      (.clk_i                              (clk_gated)
-      ,.reset_i                            (~rst_n_f)
+      (.clk_i                               (clk_gated)
+      ,.reset_i                             (~rst_n_f)
 
-      ,.transducer_l15_rqtype              (transducer_l15_rqtype)
-      ,.transducer_l15_nc                  (transducer_l15_nc)
-      ,.transducer_l15_size                (transducer_l15_size)
-      ,.transducer_l15_val                 (transducer_l15_val)
-      ,.transducer_l15_address             (transducer_l15_address)
-      ,.transducer_l15_data                (transducer_l15_data)
-      ,.transducer_l15_l1rplway            (transducer_l15_l1rplway)
-      ,.l15_transducer_ack                 (l15_transducer_ack)
+      ,.transducer_l15_rqtype               (transducer_l15_rqtype)
+      ,.transducer_l15_nc                   (transducer_l15_nc)
+      ,.transducer_l15_size                 (transducer_l15_size)
+      ,.transducer_l15_val                  (transducer_l15_val)
+      ,.transducer_l15_address              (transducer_l15_address)
+      ,.transducer_l15_data                 (transducer_l15_data)
+      ,.transducer_l15_l1rplway             (transducer_l15_l1rplway)
+      ,.transducer_l15_threadid             (transducer_l15_threadid)
+      ,.transducer_l15_amo_op               (transducer_l15_amo_op)
+      ,.transducer_l15_prefetch             (transducer_l15_prefetch)
+      ,.transducer_l15_invalidate_cacheline (transducer_l15_invalidate_cacheline)
+      ,.transducer_l15_blockstore           (transducer_l15_blockstore)
+      ,.transducer_l15_blockinitstore       (transducer_l15_blockinitstore)
+      ,.transducer_l15_data_next_entry      (transducer_l15_data_next_entry)
+      ,.transducer_l15_csm_data             (transducer_l15_csm_data)
+      ,.l15_transducer_ack                  (l15_transducer_ack)
 
-      ,.l15_transducer_val                 (l15_transducer_val)
-      ,.l15_transducer_returntype          (l15_transducer_returntype)
-      ,.l15_transducer_data_0              (l15_transducer_data_0)
-      ,.l15_transducer_data_1              (l15_transducer_data_1)
-      ,.l15_transducer_data_2              (l15_transducer_data_2)
-      ,.l15_transducer_data_3              (l15_transducer_data_3)
-      ,.l15_transducer_noncacheable        (l15_transducer_noncacheable)
-      ,.l15_transducer_threadid            (l15_transducer_threadid)
-      ,.l15_transducer_inval_address_15_4  (l15_transducer_inval_address_15_4)
-      ,.l15_transducer_inval_icache_inval  (l15_transducer_inval_icache_inval)
-      ,.l15_transducer_inval_dcache_inval  (l15_transducer_inval_dcache_inval)
-      ,.l15_transducer_inval_icache_all_way(l15_transducer_inval_icache_all_way)
-      ,.l15_transducer_inval_dcache_all_way(l15_transducer_inval_dcache_all_way)
-      ,.l15_transducer_inval_way           (l15_transducer_inval_way)
-      ,.transducer_l15_req_ack             (transducer_l15_req_ack)
+      ,.l15_transducer_val                  (l15_transducer_val)
+      ,.l15_transducer_returntype           (l15_transducer_returntype)
+      ,.l15_transducer_data_0               (l15_transducer_data_0)
+      ,.l15_transducer_data_1               (l15_transducer_data_1)
+      ,.l15_transducer_data_2               (l15_transducer_data_2)
+      ,.l15_transducer_data_3               (l15_transducer_data_3)
+      ,.l15_transducer_noncacheable         (l15_transducer_noncacheable)
+      ,.l15_transducer_threadid             (l15_transducer_threadid)
+      ,.l15_transducer_inval_address_15_4   (l15_transducer_inval_address_15_4)
+      ,.l15_transducer_inval_icache_inval   (l15_transducer_inval_icache_inval)
+      ,.l15_transducer_inval_dcache_inval   (l15_transducer_inval_dcache_inval)
+      ,.l15_transducer_inval_icache_all_way (l15_transducer_inval_icache_all_way)
+      ,.l15_transducer_inval_dcache_all_way (l15_transducer_inval_dcache_all_way)
+      ,.l15_transducer_inval_way            (l15_transducer_inval_way)
+      ,.transducer_l15_req_ack              (transducer_l15_req_ack)
       );
     
-    // Mimicking the pico_reset module here. Could possibly replace with our own module
+    // Reset the L1.5. This must be flopped 4 cycles after rst_n_f 
     logic reset_r, reset_rr, reset_rrr, reset_rrrr;
     always_ff @(posedge clk_gated) begin
       reset_r <= rst_n_f;
@@ -867,17 +875,6 @@ if (TILE_TYPE == `BLACKPARROT_TILE) begin : g_blackparrot_core
       reset_rrrr <= reset_rrr;
     end
     assign spc_grst_l = reset_rrrr;
-
-    // Unused signals - Tieing them to zero
-    // BP -> L1.5
-    assign transducer_l15_threadid = '0;
-    assign transducer_l15_amo_op = '0;
-    assign transducer_l15_prefetch = '0;
-    assign transducer_l15_invalidate_cacheline = '0;
-    assign transducer_l15_blockstore = '0;
-    assign transducer_l15_blockinitstore = '0;
-    assign transducer_l15_data_next_entry = '0;
-    assign transducer_l15_csm_data = '0;
 
 end
 endgenerate

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -827,289 +827,57 @@ if (TILE_TYPE == `BLACKPARROT_TILE) begin : g_blackparrot_core
     //////////////////////
     // BlackParrot Core //
     //////////////////////
-    logic isync_lo, dsync_lo;
+    bp_piton_top
+      proc
+      (.clk_i                              (clk_gated)
+      ,.reset_i                            (~rst_n_f)
 
-    logic [1:0] l15_ready_lo;
-    logic [1:0] load_miss_lo;
-    logic [1:0] store_miss_lo;
-    logic [1:0][39:0] miss_addr_lo;
-    logic [1:0] store_lo;
-    logic [1:0][63:0] store_data_lo;
-    logic [1:0][1:0] size_op_lo;
-    logic [1:0][2:0] lru_way_lo;
-    logic [1:0] uncached_load_req_lo;
-    logic [1:0] uncached_store_req_lo;
-    logic [1:0][522:0] data_mem_pkt_li;
-    logic [1:0] data_mem_pkt_v_li, data_mem_pkt_yumi_lo;
-    logic [1:0][41:0] tag_mem_pkt_li;
-    logic [1:0] tag_mem_pkt_v_li, tag_mem_pkt_yumi_lo;
-    logic [1:0][10:0] stat_mem_pkt_li;
-    logic [1:0] stat_mem_pkt_v_li, stat_mem_pkt_yumi_lo;
+      ,.transducer_l15_rqtype              (transducer_l15_rqtype)
+      ,.transducer_l15_nc                  (transducer_l15_nc)
+      ,.transducer_l15_size                (transducer_l15_size)
+      ,.transducer_l15_val                 (transducer_l15_val)
+      ,.transducer_l15_address             (transducer_l15_address)
+      ,.transducer_l15_data                (transducer_l15_data)
+      ,.transducer_l15_l1rplway            (transducer_l15_l1rplway)
+      ,.l15_transducer_ack                 (l15_transducer_ack)
 
-    typedef enum logic {
-      e_lce_mode_uncached
-      ,e_lce_mode_normal
-    } bp_lce_mode_e;
-
-    typedef enum bit
-    {
-      e_cce_mode_uncached = 1'b0
-      ,e_cce_mode_normal  = 1'b1
-    } bp_cce_mode_e;
-
-    localparam dword_width_p = 64;
-    localparam csr_addr_width_p = 12;
-    localparam instr_width_p = 32;
-    localparam reg_addr_width_p = 5;
-
-//`define declare_bp_cfg_bus_s(vaddr_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp, cce_pc_width_mp, cce_instr_width_mp)
-    `declare_bp_cfg_bus_s(39, 1, 4, 4, 8, 48);
-    bp_cfg_bus_s cfg_bus_li;
-
-    assign cfg_bus_li = '{freeze: 1'b0
-                          ,icache_mode: e_lce_mode_normal
-                          ,dcache_mode: e_lce_mode_normal
-                          ,default: '0
-                          };
-
-  logic [1:0] miss_fifo_ready_lo, miss_fifo_v_li, miss_v_lo, miss_yumi_li;
-    bp_core_minimal proc (
-        .clk_i                             (clk_gated),
-        .reset_i                           (~rst_n_f),
-
-        // Configuration
-        //
-        .cfg_bus_i(cfg_bus_li),
-        .cfg_npc_data_o(),
-        .cfg_irf_data_o(),
-        .cfg_csr_data_o(),
-        .cfg_priv_data_o(),
-
-        // Miss interface
-        //
-        .lce_ready_i(l15_ready_lo),
-        .lce_miss_i(load_miss_lo | store_miss_lo | miss_v_lo),
-        .credits_full_i(1'b0),
-        .credits_empty_i(1'b1),
-
-        .load_miss_o(load_miss_lo),
-        .store_miss_o(store_miss_lo),
-        .lr_miss_o(),
-        .lr_hit_o(),
-
-        .cache_v_o(),
-        .uncached_load_req_o(uncached_load_req_lo),
-        .uncached_store_req_o(uncached_store_req_lo),
-        
-        .miss_addr_o(miss_addr_lo),
-        .lru_way_o(lru_way_lo),
-
-        // Writethrough interface
-        .store_o(store_lo),
-        .store_data_o(store_data_lo),
-        .size_op_o(size_op_lo),
-
-        // Unused
-        .dirty_o(),
-
-        // Writeback interface
-        //
-        .data_mem_data_o(),
-
-        // Uncached interface
-        //
-
-        // Timer
-        .timer_irq_i('0),
-        .software_irq_i('0),
-        .external_irq_i('0),
-        
-        .data_mem_pkt_i(data_mem_pkt_li),
-        .data_mem_pkt_v_i(data_mem_pkt_v_li),
-        .data_mem_pkt_yumi_o(data_mem_pkt_yumi_lo),
-
-        .tag_mem_pkt_i(tag_mem_pkt_li),
-        .tag_mem_pkt_v_i(tag_mem_pkt_v_li),
-        .tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_lo),
-
-        .stat_mem_pkt_i(stat_mem_pkt_li),
-        .stat_mem_pkt_v_i(stat_mem_pkt_v_li),
-        .stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_lo)
-   );
-
-    pico_reset pico_reset(
-        .gclk(clk_gated),
-        .rst_n(rst_n_f),
-        .spc_grst_l(spc_grst_l)
-    );
-
-  logic [1:0][39:0] miss_addr_fifo_lo;
-  logic [1:0][1:0] miss_size_op_lo;
-  logic [1:0][2:0] miss_lru_lo;
-  logic [1:0] is_store_lo;
-  logic [1:0] uncached_lo;
-  logic [1:0][63:0] miss_data_fifo_lo;
-  logic transducer_ready_lo;
-  for (genvar i = 0; i < 2; i++) begin : miss_fifo
-    assign miss_fifo_v_li[i] = load_miss_lo[i] | store_miss_lo[i] | store_lo[i] | uncached_store_req_lo[i] | uncached_load_req_lo[i];
-    wire is_store_li = store_lo[i] | uncached_store_req_lo[i];
-    wire uncached_li = uncached_store_req_lo[i] | uncached_load_req_lo[i];
-    bsg_one_fifo
-     #(.width_p(40+3+1+1+2+64))
-     miss_fifo
-      (.clk_i(clk)
-       ,.reset_i(~rst_n_f)
-
-       ,.data_i({uncached_li, is_store_li, lru_way_lo[i], size_op_lo[i], miss_addr_lo[i], store_data_lo[i]})
-       ,.v_i(miss_fifo_v_li[i])
-       ,.ready_o(miss_fifo_ready_lo[i])
-
-       ,.data_o({uncached_lo[i], is_store_lo[i], miss_lru_lo[i], miss_size_op_lo[i], miss_addr_fifo_lo[i], miss_data_fifo_lo[i]})
-       ,.v_o(miss_v_lo[i])
-       ,.yumi_i(miss_yumi_li[i])
-       );
-    assign l15_ready_lo[i] = (miss_fifo_ready_lo[i] & transducer_ready_lo);
-  end
-
-  logic        arb_miss_v_lo;
-  logic        arb_miss_yumi_li;
-  logic        arb_uncached_lo;
-  logic [39:0] arb_miss_addr_lo;
-  logic [2:0]  arb_miss_lru_lo;
-  logic        arb_is_store_lo;
-  logic [63:0] arb_miss_data_lo;
-  logic [1:0]  arb_miss_size_lo;
-  
-  logic [522:0] arb_data_mem_pkt_li;
-  logic arb_data_mem_pkt_v_li, arb_data_mem_pkt_yumi_lo;
-  logic [41:0] arb_tag_mem_pkt_li;
-  logic arb_tag_mem_pkt_v_li, arb_tag_mem_pkt_yumi_lo;
-  logic [10:0] arb_stat_mem_pkt_li;
-  logic arb_stat_mem_pkt_v_li, arb_stat_mem_pkt_yumi_lo;
-
-  // Fixme: Won't work if dcache requests while icache is being serviced
-  always_comb begin
-    if (miss_v_lo[1] | dsync_lo) begin
-      arb_miss_v_lo = miss_v_lo[1];
-      arb_uncached_lo = uncached_lo[1];
-      arb_miss_addr_lo = miss_addr_fifo_lo[1];
-      arb_miss_lru_lo = miss_lru_lo[1];
-      arb_is_store_lo = is_store_lo[1];
-      arb_miss_data_lo = miss_data_fifo_lo[1];
-      arb_miss_size_lo = miss_size_op_lo[1];
-
-      miss_yumi_li[0] = '0;
-      miss_yumi_li[1] = arb_miss_yumi_li;
-
-      data_mem_pkt_li[0] = '0;
-      data_mem_pkt_v_li[0] = '0;
-      data_mem_pkt_li[1] = arb_data_mem_pkt_li;
-      data_mem_pkt_v_li[1] = arb_data_mem_pkt_v_li;
-      arb_data_mem_pkt_yumi_lo = data_mem_pkt_yumi_lo[1];
-
-      tag_mem_pkt_li[0] = '0;
-      tag_mem_pkt_v_li[0] = '0;
-      tag_mem_pkt_li[1] = arb_tag_mem_pkt_li;
-      tag_mem_pkt_v_li[1] = arb_tag_mem_pkt_v_li;
-      arb_tag_mem_pkt_yumi_lo = tag_mem_pkt_yumi_lo[1];
-
-      stat_mem_pkt_li[0] = '0;
-      stat_mem_pkt_v_li[0] = '0;
-      stat_mem_pkt_li[1] = arb_stat_mem_pkt_li;
-      stat_mem_pkt_v_li[1] = arb_stat_mem_pkt_v_li;
-      arb_stat_mem_pkt_yumi_lo = stat_mem_pkt_yumi_lo[1];
-
-    end else begin
-      arb_miss_v_lo = miss_v_lo[0];
-      arb_uncached_lo = uncached_lo[0];
-      arb_miss_addr_lo = miss_addr_fifo_lo[0];
-      arb_miss_lru_lo = miss_lru_lo[0];
-      arb_is_store_lo = is_store_lo[0];
-      arb_miss_data_lo = miss_data_fifo_lo[0];
-      arb_miss_size_lo = miss_size_op_lo[0];
-
-      miss_yumi_li[0] = arb_miss_yumi_li;
-      miss_yumi_li[1] = '0;
-
-      data_mem_pkt_li[0] = arb_data_mem_pkt_li;
-      data_mem_pkt_v_li[0] = arb_data_mem_pkt_v_li;
-      arb_data_mem_pkt_yumi_lo = data_mem_pkt_yumi_lo[0];
-      data_mem_pkt_li[1] = '0;
-      data_mem_pkt_v_li[1] = '0;
-
-      tag_mem_pkt_li[0] = arb_tag_mem_pkt_li;
-      tag_mem_pkt_v_li[0] = arb_tag_mem_pkt_v_li;
-      arb_tag_mem_pkt_yumi_lo = tag_mem_pkt_yumi_lo[0];
-      tag_mem_pkt_li[1] = '0;
-      tag_mem_pkt_v_li[1] = '0;
-
-      stat_mem_pkt_li[0] = arb_stat_mem_pkt_li;
-      stat_mem_pkt_v_li[0] = arb_stat_mem_pkt_v_li;
-      arb_stat_mem_pkt_yumi_lo = stat_mem_pkt_yumi_lo[0];
-      stat_mem_pkt_li[1] = '0;
-      stat_mem_pkt_v_li[1] = '0;
+      ,.l15_transducer_val                 (l15_transducer_val)
+      ,.l15_transducer_returntype          (l15_transducer_returntype)
+      ,.l15_transducer_data_0              (l15_transducer_data_0)
+      ,.l15_transducer_data_1              (l15_transducer_data_1)
+      ,.l15_transducer_data_2              (l15_transducer_data_2)
+      ,.l15_transducer_data_3              (l15_transducer_data_3)
+      ,.l15_transducer_noncacheable        (l15_transducer_noncacheable)
+      ,.l15_transducer_threadid            (l15_transducer_threadid)
+      ,.l15_transducer_inval_address_15_4  (l15_transducer_inval_address_15_4)
+      ,.l15_transducer_inval_icache_inval  (l15_transducer_inval_icache_inval)
+      ,.l15_transducer_inval_dcache_inval  (l15_transducer_inval_dcache_inval)
+      ,.l15_transducer_inval_icache_all_way(l15_transducer_inval_icache_all_way)
+      ,.l15_transducer_inval_dcache_all_way(l15_transducer_inval_dcache_all_way)
+      ,.l15_transducer_inval_way           (l15_transducer_inval_way)
+      ,.transducer_l15_req_ack             (transducer_l15_req_ack)
+      );
+    
+    // Mimicking the pico_reset module here. Could possibly replace with our own module
+    logic reset_r, reset_rr, reset_rrr, reset_rrrr;
+    always_ff @(posedge clk_gated) begin
+      reset_r <= rst_n_f;
+      reset_rr <= reset_r;
+      reset_rrr <= reset_rr;
+      reset_rrrr <= reset_rrr;
     end
-  end
+    assign spc_grst_l = reset_rrrr;
 
-    bp_l15_transducer bp_l15_transducer(
-        .clk_i                              (clk),
-        .reset_i                            (~rst_n_f),
-
-        .isync_o                            (isync_lo),
-        .dsync_o                            (dsync_lo),
-        .ready_o                            (transducer_ready_lo),
-        // OpenPiton Bus
-        // BP -> L1.5
-        .miss_v_i                           (arb_miss_v_lo),
-        .miss_yumi_o                        (arb_miss_yumi_li),
-        .uncached_i                         (arb_uncached_lo),
-        .miss_addr_i                        (arb_miss_addr_lo),
-        .lru_way_i                          (arb_miss_lru_lo),
-        .store_i                            (arb_is_store_lo),
-        .store_data_i                       (arb_miss_data_lo),
-        .size_op_i                          (arb_miss_size_lo),
-
-        // L1.5 -> BP
-        .l15_transducer_ack                 (l15_transducer_ack),
-        .l15_transducer_header_ack          (l15_transducer_header_ack),
-
-        .transducer_l15_rqtype              (transducer_l15_rqtype),
-        .transducer_l15_amo_op              (transducer_l15_amo_op),
-        .transducer_l15_size                (transducer_l15_size),
-        .transducer_l15_val                 (transducer_l15_val),
-        .transducer_l15_address             (transducer_l15_address),
-        .transducer_l15_data                (transducer_l15_data),
-
-        .transducer_l15_nc                  (transducer_l15_nc),
-        .transducer_l15_threadid            (transducer_l15_threadid),
-        .transducer_l15_prefetch            (transducer_l15_prefetch),
-        .transducer_l15_blockstore          (transducer_l15_blockstore),
-        .transducer_l15_blockinitstore      (transducer_l15_blockinitstore),
-        .transducer_l15_l1rplway            (transducer_l15_l1rplway),
-        .transducer_l15_invalidate_cacheline(transducer_l15_invalidate_cacheline),
-        .transducer_l15_csm_data            (transducer_l15_csm_data),
-        .transducer_l15_data_next_entry     (transducer_l15_data_next_entry),
-
-        .l15_transducer_val                 (l15_transducer_val),
-        .l15_transducer_returntype          (l15_transducer_returntype),
-
-        .l15_transducer_data_0              (l15_transducer_data_0),
-        .l15_transducer_data_1              (l15_transducer_data_1),
-
-        .transducer_l15_req_ack             (transducer_l15_req_ack),
-
-        .data_mem_pkt_o                     (arb_data_mem_pkt_li),
-        .data_mem_pkt_v_o                   (arb_data_mem_pkt_v_li),
-        .data_mem_pkt_yumi_i                (arb_data_mem_pkt_yumi_lo),
-
-        .tag_mem_pkt_o                      (arb_tag_mem_pkt_li),
-        .tag_mem_pkt_v_o                    (arb_tag_mem_pkt_v_li),
-        .tag_mem_pkt_yumi_i                 (arb_tag_mem_pkt_yumi_lo),
-
-        .stat_mem_pkt_o                     (arb_stat_mem_pkt_li),
-        .stat_mem_pkt_v_o                   (arb_stat_mem_pkt_v_li),
-        .stat_mem_pkt_yumi_i                (arb_stat_mem_pkt_yumi_lo)
-    );
+    // Unused signals - Tieing them to zero
+    // BP -> L1.5
+    assign transducer_l15_threadid = '0;
+    assign transducer_l15_amo_op = '0;
+    assign transducer_l15_prefetch = '0;
+    assign transducer_l15_invalidate_cacheline = '0;
+    assign transducer_l15_blockstore = '0;
+    assign transducer_l15_blockinitstore = '0;
+    assign transducer_l15_data_next_entry = '0;
+    assign transducer_l15_csm_data = '0;
 
 end
 endgenerate

--- a/piton/design/chipset/rtl/chipset_impl.v.pyv
+++ b/piton/design/chipset/rtl/chipset_impl.v.pyv
@@ -1079,8 +1079,8 @@ ciop_fake_iob ciop_fake_iob(
           .pc_w0             ( `ARIANE_CORE0.piton_pc[48:0] ),
         `endif
         `ifdef RTL_BLACKPARROT0
-          .spc0_inst_done    ( `BLACKPARROT_CORE0.be.be_checker.director.commit_pkt.instret ),
-          .pc_w0             ( `BLACKPARROT_CORE0.be.be_checker.director.commit_pkt.pc      ),
+          .spc0_inst_done    ( `BLACKPARROT_CORE0.core.be.be_checker.director.commit_pkt.instret ),
+          .pc_w0             ( `BLACKPARROT_CORE0.core.be.be_checker.director.commit_pkt.pc      ),
         `endif
         '''
 

--- a/piton/tools/src/proto/protosyn,2.5
+++ b/piton/tools/src/proto/protosyn,2.5
@@ -727,7 +727,7 @@ def main():
 
     # core variant
     print_info("core      = " + str(options.core))
-    for i in range(int(args.num_tiles)):
+    for i in range(int(options.num_tiles)):
         os.environ['RTL_TILE' + str(i)] = "1"
         print_info('defining RTL_TILE' + str(i))
 

--- a/piton/tools/src/sims/manycore.config
+++ b/piton/tools/src/sims/manycore.config
@@ -25,7 +25,7 @@
     -model=manycore
     -toplevel=cmp_top
 #ifdef FLIST_BLACKPARROT
-    -flist=$DV_ROOT/design/chip/tile/blackparrot/bp_top/syn/piton_flist.vcs
+    -flist=$DV_ROOT/design/chip/tile/blackparrot/bp_top/syn/flist.vcs
 #endif
     -flist=$DV_ROOT/design/include/Flist.include
     -flist=$DV_ROOT/design/common/rtl/Flist.common

--- a/piton/tools/src/sims/manycore.config
+++ b/piton/tools/src/sims/manycore.config
@@ -25,7 +25,7 @@
     -model=manycore
     -toplevel=cmp_top
 #ifdef FLIST_BLACKPARROT
-    -flist=$DV_ROOT/design/chip/tile/blackparrot/bp_top/syn/flist.vcs
+    -flist=$DV_ROOT/design/chip/tile/blackparrot/bp_top/syn/piton_flist.vcs
 #endif
     -flist=$DV_ROOT/design/include/Flist.include
     -flist=$DV_ROOT/design/common/rtl/Flist.common

--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -2227,9 +2227,9 @@ sub assemble_diag
     my $diag_name ;
     if ($opt{asm_diag_name} =~ /\.pal/)        { $diag_name = "diag.pal"  ; }
     elsif ($opt{asm_diag_name} =~ /\.s\.gz/)   { $diag_name = "diag.s.gz" ; }
-    elsif ($opt{precompiled} and $opt{ariane}) { $diag_name = "diag.exe"  ; }
-    elsif (($opt{pico} | $opt{ariane}) and ($opt{asm_diag_name} =~ /\.S/)) { $diag_name = "diag.S" ; }
-    elsif (($opt{pico} | $opt{ariane}) and ($opt{asm_diag_name} =~ /\.c/)) { $diag_name = "diag.c" ; }
+    elsif ($opt{precompiled} and ($opt{rv32} | $opt{rv64})) { $diag_name = "diag.exe"  ; }
+    elsif (($opt{rv32} | $opt{rv64}) and ($opt{asm_diag_name} =~ /\.S/)) { $diag_name = "diag.S" ; }
+    elsif (($opt{rv32} | $opt{rv64}) and ($opt{asm_diag_name} =~ /\.c/)) { $diag_name = "diag.c" ; }
     else { $diag_name = "diag.s" ; }
 
     # copy diagnostic to run area
@@ -2725,7 +2725,7 @@ sub parse_args
   }
 
   # in case a precompiled riscv binary for ariane is directly specified
-  if ($opt{precompiled} and $opt{ariane}) {
+  if ($opt{precompiled} and ($opt{rv32} | $opt{rv64})) {
     if (!($opt{asm_diag_name} =~ /\.riscv/)) {
         $opt{asm_diag_name} = fileparse($opt{asm_diag_name}, qr/\.[^.]*/);
     }
@@ -2826,9 +2826,9 @@ sub parse_args
     $pton_y_tiles=$opt{y_tiles};
     $pton_num_tiles=($opt{x_tiles} * $opt{y_tiles});
   } else {
-    print "x_tiles and y_tiles not defined, assuming x dimension is <= 8\n" ;
+    print "$prg: x_tiles and y_tiles not defined, assuming x dimension is <= 8\n" ;
     if (! $opt{num_tile}) {
-        print "num_tile not defined, assuming just one tile\n" ;
+        print "$prg: num_tile not defined, assuming just one tile\n" ;
         $opt{num_tile} = 1;
     }
 

--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -355,7 +355,7 @@ die ("DIE. -pico and -pico_het cannot both be set") if ($opt{pico} && $opt{pico_
 
 # Setting ost1 by default. This works better than default to 1
 # for heterogeneous-ISA stuff
-if (!$opt{pico} && !$opt{ariane}) {
+if (!$opt{pico} && !$opt{ariane} && !$opt{blackparrot}) {
   $opt{ost1} = 1 ;
 }
 
@@ -1140,7 +1140,7 @@ sub gen_flist
       $line =~ s/^\s*(.*?)\s*$/$1/ ;
       $line .= "\n" ;
 
-      if (($line =~ /^\s*\/\//) or ($line =~ /^\s*$/)) {
+      if (($line =~ /^\s*\/\//) or ($line =~ /^\s*$/) or ($line =~ /^\s*#/)) {
         next ;
       }
 
@@ -2221,7 +2221,7 @@ sub assemble_diag
     }
 
     if ($opt{blackparrot} and $opt{precompiled}) {
-      push @{$opt{asm_diag_root}}, "$ENV{HOME}/scratch/pre-alpha-release/bp_common/test/mem/";
+      push @{$opt{asm_diag_root}}, "$ENV{HOME}/BlackParrot/black-parrot/bp_common/test/mem/";
     }
 
     # find diagnostic

--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -2221,7 +2221,7 @@ sub assemble_diag
     }
 
     if ($opt{blackparrot} and $opt{precompiled}) {
-      push @{$opt{asm_diag_root}}, "$ENV{HOME}/BlackParrot/black-parrot/bp_common/test/mem/";
+      push @{$opt{asm_diag_root}}, "$ENV{DV_ROOT}/piton/design/chip/tile/blackparrot/bp_common/test/mem/";
     }
 
     # find diagnostic

--- a/piton/verif/diag/master_diaglist_princeton
+++ b/piton/verif/diag/master_diaglist_princeton
@@ -86,6 +86,138 @@ pico-amoxor     amoxor_w.S
 </cmp_default>
 </pico_tile1>
 
+<blackparrot_tile1 sys=manycore -x_tiles=1 -y_tiles=1 -blackparrot>
+<cmp_default name=default>
+    // note: these asm tests assume that the RISCV tests have been precompiled with the
+    // correct environment
+    <blackparrot_tile1_asm_tests_p>
+        <runargs -x_tiles=1 -y_tiles=1 -blackparrot -precompiled>
+        blackparrot-rv64ui-p-add       rv64ui-p-add.riscv
+        blackparrot-rv64ui-p-addi      rv64ui-p-addi.riscv
+        blackparrot-rv64ui-p-addiw     rv64ui-p-addiw.riscv
+        blackparrot-rv64ui-p-addw      rv64ui-p-addw.riscv
+        blackparrot-rv64ui-p-and       rv64ui-p-and.riscv
+        blackparrot-rv64ui-p-andi      rv64ui-p-andi.riscv
+        blackparrot-rv64ui-p-auipc     rv64ui-p-auipc.riscv
+        blackparrot-rv64ui-p-beq       rv64ui-p-beq.riscv
+        blackparrot-rv64ui-p-bge       rv64ui-p-bge.riscv
+        blackparrot-rv64ui-p-bgeu      rv64ui-p-bgeu.riscv
+        blackparrot-rv64ui-p-blt       rv64ui-p-blt.riscv
+        blackparrot-rv64ui-p-bltu      rv64ui-p-bltu.riscv
+        blackparrot-rv64ui-p-bne       rv64ui-p-bne.riscv
+        blackparrot-rv64ui-p-fence_i   rv64ui-p-fence_i.riscv
+        blackparrot-rv64ui-p-jal       rv64ui-p-jal.riscv
+        blackparrot-rv64ui-p-jalr      rv64ui-p-jalr.riscv
+        blackparrot-rv64ui-p-lb        rv64ui-p-lb.riscv
+        blackparrot-rv64ui-p-lbu       rv64ui-p-lbu.riscv
+        blackparrot-rv64ui-p-ld        rv64ui-p-ld.riscv
+        blackparrot-rv64ui-p-lh        rv64ui-p-lh.riscv
+        blackparrot-rv64ui-p-lhu       rv64ui-p-lhu.riscv
+        blackparrot-rv64ui-p-lui       rv64ui-p-lui.riscv
+        blackparrot-rv64ui-p-lw        rv64ui-p-lw.riscv
+        blackparrot-rv64ui-p-lwu       rv64ui-p-lwu.riscv
+        blackparrot-rv64ui-p-or        rv64ui-p-or.riscv
+        blackparrot-rv64ui-p-ori       rv64ui-p-ori.riscv
+        blackparrot-rv64ui-p-sb        rv64ui-p-sb.riscv
+        blackparrot-rv64ui-p-sd        rv64ui-p-sd.riscv
+        blackparrot-rv64ui-p-sh        rv64ui-p-sh.riscv
+        blackparrot-rv64ui-p-sw        rv64ui-p-sw.riscv
+        // blackparrot-rv64ui-p-simple    rv64ui-p-simple.riscv
+        blackparrot-rv64ui-p-sll       rv64ui-p-sll.riscv
+        blackparrot-rv64ui-p-slli      rv64ui-p-slli.riscv
+        blackparrot-rv64ui-p-slliw     rv64ui-p-slliw.riscv
+        blackparrot-rv64ui-p-sllw      rv64ui-p-sllw.riscv
+        blackparrot-rv64ui-p-slt       rv64ui-p-slt.riscv
+        blackparrot-rv64ui-p-slti      rv64ui-p-slti.riscv
+        blackparrot-rv64ui-p-sltiu     rv64ui-p-sltiu.riscv
+        blackparrot-rv64ui-p-sltu      rv64ui-p-sltu.riscv
+        blackparrot-rv64ui-p-sra       rv64ui-p-sra.riscv
+        blackparrot-rv64ui-p-srai      rv64ui-p-srai.riscv
+        blackparrot-rv64ui-p-sraiw     rv64ui-p-sraiw.riscv
+        blackparrot-rv64ui-p-sraw      rv64ui-p-sraw.riscv
+        blackparrot-rv64ui-p-srl       rv64ui-p-srl.riscv
+        blackparrot-rv64ui-p-srli      rv64ui-p-srli.riscv
+        blackparrot-rv64ui-p-srliw     rv64ui-p-srliw.riscv
+        blackparrot-rv64ui-p-srlw      rv64ui-p-srlw.riscv
+        blackparrot-rv64ui-p-sub       rv64ui-p-sub.riscv
+        blackparrot-rv64ui-p-subw      rv64ui-p-subw.riscv
+        blackparrot-rv64ui-p-xor       rv64ui-p-xor.riscv
+        blackparrot-rv64ui-p-xori      rv64ui-p-xori.riscv
+        blackparrot-rv64um-p-mul       rv64um-p-mul.riscv
+        blackparrot-rv64um-p-mulh      rv64um-p-mulh.riscv
+        blackparrot-rv64um-p-mulhsu    rv64um-p-mulhsu.riscv
+        blackparrot-rv64um-p-mulhu     rv64um-p-mulhu.riscv
+        blackparrot-rv64um-p-mulw      rv64um-p-mulw.riscv
+        blackparrot-rv64um-p-div       rv64um-p-div.riscv
+        blackparrot-rv64um-p-divu      rv64um-p-divu.riscv
+        blackparrot-rv64um-p-divw      rv64um-p-divw.riscv
+        blackparrot-rv64um-p-divuw     rv64um-p-divuw.riscv
+        blackparrot-rv64um-p-rem       rv64um-p-rem.riscv
+        blackparrot-rv64um-p-remu      rv64um-p-remu.riscv
+        blackparrot-rv64um-p-remw      rv64um-p-remw.riscv
+        blackparrot-rv64um-p-remuw     rv64um-p-remuw.riscv
+        </runargs>
+    </blackparrot_tile1_asm_tests_p>
+    
+    // note: these asm tests assume that the RISCV tests have been precompiled with the
+    // correct environment
+    <blackparrot_tile1_asm_tests_v>
+        <runargs -x_tiles=1 -y_tiles=1 -blackparrot -precompiled -trap_offset=0x80000000>
+        blackparrot-rv64ui-v-add       rv64ui-v-add.riscv
+        blackparrot-rv64ui-v-addi      rv64ui-v-addi.riscv
+        blackparrot-rv64ui-v-addiw     rv64ui-v-addiw.riscv
+        blackparrot-rv64ui-v-addw      rv64ui-v-addw.riscv
+        blackparrot-rv64ui-v-and       rv64ui-v-and.riscv
+        blackparrot-rv64ui-v-andi      rv64ui-v-andi.riscv
+        blackparrot-rv64ui-v-auipc     rv64ui-v-auipc.riscv
+        blackparrot-rv64ui-v-beq       rv64ui-v-beq.riscv
+        blackparrot-rv64ui-v-bge       rv64ui-v-bge.riscv
+        blackparrot-rv64ui-v-bgeu      rv64ui-v-bgeu.riscv
+        blackparrot-rv64ui-v-blt       rv64ui-v-blt.riscv
+        blackparrot-rv64ui-v-bltu      rv64ui-v-bltu.riscv
+        blackparrot-rv64ui-v-bne       rv64ui-v-bne.riscv
+        blackparrot-rv64ui-v-fence_i   rv64ui-v-fence_i.riscv
+        blackparrot-rv64ui-v-jal       rv64ui-v-jal.riscv
+        blackparrot-rv64ui-v-jalr      rv64ui-v-jalr.riscv
+        blackparrot-rv64ui-v-lb        rv64ui-v-lb.riscv
+        blackparrot-rv64ui-v-lbu       rv64ui-v-lbu.riscv
+        blackparrot-rv64ui-v-ld        rv64ui-v-ld.riscv
+        blackparrot-rv64ui-v-lh        rv64ui-v-lh.riscv
+        blackparrot-rv64ui-v-lhu       rv64ui-v-lhu.riscv
+        blackparrot-rv64ui-v-lui       rv64ui-v-lui.riscv
+        blackparrot-rv64ui-v-lw        rv64ui-v-lw.riscv
+        blackparrot-rv64ui-v-lwu       rv64ui-v-lwu.riscv
+        blackparrot-rv64ui-v-or        rv64ui-v-or.riscv
+        blackparrot-rv64ui-v-ori       rv64ui-v-ori.riscv
+        blackparrot-rv64ui-v-sb        rv64ui-v-sb.riscv
+        blackparrot-rv64ui-v-sd        rv64ui-v-sd.riscv
+        blackparrot-rv64ui-v-sh        rv64ui-v-sh.riscv
+        blackparrot-rv64ui-v-sw        rv64ui-v-sw.riscv
+        // blackparrot-rv64ui-p-simple    rv64ui-p-simple.riscv
+        blackparrot-rv64ui-v-sll       rv64ui-v-sll.riscv
+        blackparrot-rv64ui-v-slli      rv64ui-v-slli.riscv
+        blackparrot-rv64ui-v-slliw     rv64ui-v-slliw.riscv
+        blackparrot-rv64ui-v-sllw      rv64ui-v-sllw.riscv
+        blackparrot-rv64ui-v-slt       rv64ui-v-slt.riscv
+        blackparrot-rv64ui-v-slti      rv64ui-v-slti.riscv
+        blackparrot-rv64ui-v-sltiu     rv64ui-v-sltiu.riscv
+        blackparrot-rv64ui-v-sltu      rv64ui-v-sltu.riscv
+        blackparrot-rv64ui-v-sra       rv64ui-v-sra.riscv
+        blackparrot-rv64ui-v-srai      rv64ui-v-srai.riscv
+        blackparrot-rv64ui-v-sraiw     rv64ui-v-sraiw.riscv
+        blackparrot-rv64ui-v-sraw      rv64ui-v-sraw.riscv
+        blackparrot-rv64ui-v-srl       rv64ui-v-srl.riscv
+        blackparrot-rv64ui-v-srli      rv64ui-v-srli.riscv
+        blackparrot-rv64ui-v-srliw     rv64ui-v-srliw.riscv
+        blackparrot-rv64ui-v-srlw      rv64ui-v-srlw.riscv
+        blackparrot-rv64ui-v-sub       rv64ui-v-sub.riscv
+        blackparrot-rv64ui-v-subw      rv64ui-v-subw.riscv
+        blackparrot-rv64ui-v-xor       rv64ui-v-xor.riscv
+        blackparrot-rv64ui-v-xori      rv64ui-v-xori.riscv
+        </runargs>
+    </blackparrot_tile1_asm_tests_v>
+</cmp_default>
+</blackparrot_tile1>
 
 <ariane_tile1 sys=manycore -x_tiles=1 -y_tiles=1 -ariane>
 <cmp_default name=default>

--- a/piton/verif/env/manycore/cross_module.h.pyv
+++ b/piton/verif/env/manycore/cross_module.h.pyv
@@ -102,15 +102,6 @@ for i in range(NUM_TILES):
     `define ARIANE_CORE%d     `TILE%d.g_ariane_core.core.ariane
     `define SPARC_CORE%d      `TILE%d.g_sparc_core.core
     `define PICO_CORE%d       `TILE%d.g_picorv32_core.core
-    `ifdef RTL_SPARC%d
-    `define CORE_REF%d        `SPARC_CORE%d
-    `endif // ifdef RTL_SPARC%d
-    `ifdef RTL_ARIANE%d
-    `define CORE_REF%d        `TILE%d.g_ariane_core.core
-    `endif // ifdef RTL_ARIANE%d
-    `ifdef RTL_PICO%d
-    `define CORE_REF%d        `PICO_CORE%d
-    `endif // ifdef RTL_PICO%d
     `define CCX_TRANSDUCER%d  `TILE%d.g_sparc_core.ccx_l15_transducer
     `define PICO_TRANSDUCER%d `TILE%d.g_picorv32_core.pico_l15_transducer
     `define L15_TOP%d         `TILE%d.l15.l15

--- a/piton/verif/env/manycore/cross_module.h.pyv
+++ b/piton/verif/env/manycore/cross_module.h.pyv
@@ -102,6 +102,7 @@ for i in range(NUM_TILES):
     `define ARIANE_CORE%d     `TILE%d.g_ariane_core.core.ariane
     `define SPARC_CORE%d      `TILE%d.g_sparc_core.core
     `define PICO_CORE%d       `TILE%d.g_picorv32_core.core
+    `define BLACKPARROT_CORE%d `TILE%d.g_blackparrot_core.proc
     `define CCX_TRANSDUCER%d  `TILE%d.g_sparc_core.ccx_l15_transducer
     `define PICO_TRANSDUCER%d `TILE%d.g_picorv32_core.pico_l15_transducer
     `define L15_TOP%d         `TILE%d.l15.l15

--- a/piton/verif/env/manycore/manycore_top.v.pyv
+++ b/piton/verif/env/manycore/manycore_top.v.pyv
@@ -430,7 +430,7 @@ system system(
     monitor   monitor(
         .clk    (`CHIP_INT_CLK),
         .cmp_gclk  (`CHIP_INT_CLK),
-        .rst_l     (`CORE_REF0.reset_l)
+        .rst_l     (`CHIP.rst_n_inter_sync)
         );
 
 `ifndef MINIMAL_MONITORING
@@ -487,7 +487,7 @@ system system(
 
 `ifndef VERILATOR
     // T1's TSO monitor, stripped of all L2 references
-    tso_mon tso_mon(`CHIP_INT_CLK, `CORE_REF0.reset_l);
+    tso_mon tso_mon(`CHIP_INT_CLK, `CHIP.rst_n_inter_sync);
 `endif
 
     // L15 MONITORS
@@ -534,7 +534,7 @@ system system(
     sas_intf  sas_intf(/*AUTOINST*/
         // Inputs
         .clk       (`CHIP_INT_CLK),      // Templated
-        .rst_l     (`CORE_REF0.reset_l));       // Templated
+        .rst_l     (`CHIP.rst_n_inter_sync));       // Templated
 `endif
 
 `ifdef PITON_OST1
@@ -542,7 +542,7 @@ system system(
     sas_tasks sas_tasks(/*AUTOINST*/
         // Inputs
         .clk      (`CHIP_INT_CLK),      // Templated
-        .rst_l        (`CORE_REF0.reset_l));       // Templated
+        .rst_l        (`CHIP.rst_n_inter_sync));       // Templated
 `endif
 
 `ifdef PITON_OST1

--- a/piton/verif/env/manycore/monitor.v.pyv
+++ b/piton/verif/env/manycore/monitor.v.pyv
@@ -1287,11 +1287,6 @@ module monitor(/*AUTOARG*/
 //dump cache
 `endif // ifdef RTL_TILE0
 
-`ifdef RTL_BLACKPARROT0
-   //monitor good trap and bad trap.
-   pc_cmp pc_cmp(clk, rst_l); // Sumti - Shifting it back to clk, sas race with +fast_boot.
-`endif // ifdef RTL_BLACKPARROT0
-
 	// dump_cache dump_cache();
 
 	// Don't include this section if compiling for DRAM SAT Environment

--- a/piton/verif/env/manycore/pc_cmp.v.pyv
+++ b/piton/verif/env/manycore/pc_cmp.v.pyv
@@ -258,8 +258,8 @@ endtask // get_thread_status
                 end
 
                 always @(posedge clk) begin
-                      spc0_inst_done         <= `BLACKPARROT_CORE0.be.be_checker.director.commit_pkt.instret;
-                      spc0_phy_pc_w          <= 48'($signed(48'(`BLACKPARROT_CORE0.be.be_checker.director.commit_pkt.pc)));
+                      spc0_inst_done         <= `BLACKPARROT_CORE0.core.be.be_checker.director.commit_pkt.instret;
+                      spc0_phy_pc_w          <= 48'($signed(48'(`BLACKPARROT_CORE0.core.be.be_checker.director.commit_pkt.pc)));
                 end
         `else
         `ifdef RTL_PICO0


### PR DESCRIPTION
This PR adds the updated BlackParrot tile to OpenPiton. 

This features a new P-Mesh Cache Engine that supports cacheable loads and stores and remote invalidations

RISC-V p and v tests pass