### PR TITLE
Adjusted testbenches upload

### DIFF
--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64-helloworld.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64-helloworld.S
@@ -1,0 +1,181 @@
+    lui x1, 0xf0c2c
+    # Print Hello world
+    li  x3, 0x48
+    sb  x3, 0(x1)
+    li  x3, 0x65
+    sb  x3, 0(x1)
+    li  x3, 0x6c
+    sb  x3, 0(x1)
+    li  x3, 0x6c
+    sb  x3, 0(x1)
+    li  x3, 0x6F
+    sb  x3, 0(x1)
+    li  x3, 0x20
+    sb  x3, 0(x1)
+    li  x3, 0x77
+    sb  x3, 0(x1)
+    li  x3, 0x6f
+    sb  x3, 0(x1)
+    li  x3, 0x72
+    sb  x3, 0(x1)
+    li  x3, 0x6c
+    sb  x3, 0(x1)
+    li  x3, 0x64
+    sb  x3, 0(x1)
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+# sit in loop and increment counter, because why not
+pass:
+    addi x2, x0, 0
+loop:     
+    addi    x2,x2,1
+    j       loop

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fadd.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fadd.S
@@ -1,0 +1,50 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fadd.S
+#-----------------------------------------------------------------------------
+#
+# Test f{add|sub|mul}.d instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_OP2_D
+    #define TEST_FP_OP2_D TEST_FP_OP2_D32
+#endif
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FP_OP2_D( 2,  fadd.d, 0,                3.5,        2.5,        1.0 );
+  TEST_FP_OP2_D( 3,  fadd.d, 1,              -1234,    -1235.1,        1.1 );
+  TEST_FP_OP2_D( 4,  fadd.d, 1,         3.14159266, 3.14159265, 0.00000001 );
+
+  TEST_FP_OP2_D( 5,  fsub.d, 0,                1.5,        2.5,        1.0 );
+  TEST_FP_OP2_D( 6,  fsub.d, 1,              -1234,    -1235.1,       -1.1 );
+  TEST_FP_OP2_D( 7,  fsub.d, 1, 3.1415926400000001, 3.14159265, 0.00000001 );
+
+  TEST_FP_OP2_D( 8,  fmul.d, 0,                2.5,        2.5,        1.0 );
+  TEST_FP_OP2_D( 9,  fmul.d, 1,            1358.61,    -1235.1,       -1.1 );
+  TEST_FP_OP2_D(10,  fmul.d, 1,      3.14159265e-8, 3.14159265, 0.00000001 );
+
+  # Is the canonical NaN generated for Inf - Inf?
+  TEST_FP_OP2_D(11,  fsub.d, 0x10, qNaN, Inf, Inf);
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fclass.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fclass.S
@@ -1,0 +1,46 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fclass.S
+#-----------------------------------------------------------------------------
+#
+# Test fclass.d instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FCLASS_D
+    #define TEST_FCLASS_D TEST_FCLASS_D32
+#endif
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FCLASS_D( 2, 1 << 0, 0xfff0000000000000 )
+  TEST_FCLASS_D( 3, 1 << 1, 0xbff0000000000000 )
+  TEST_FCLASS_D( 4, 1 << 2, 0x800fffffffffffff )
+  TEST_FCLASS_D( 5, 1 << 3, 0x8000000000000000 )
+  TEST_FCLASS_D( 6, 1 << 4, 0x0000000000000000 )
+  TEST_FCLASS_D( 7, 1 << 5, 0x000fffffffffffff )
+  TEST_FCLASS_D( 8, 1 << 6, 0x3ff0000000000000 )
+  TEST_FCLASS_D( 9, 1 << 7, 0x7ff0000000000000 )
+  TEST_FCLASS_D(10, 1 << 8, 0x7ff0000000000001 )
+  TEST_FCLASS_D(11, 1 << 9, 0x7ff8000000000000 )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fcmp.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fcmp.S
@@ -1,0 +1,56 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fcmp.S
+#-----------------------------------------------------------------------------
+#
+# Test f{eq|lt|le}.d instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_CMP_OP_D
+    #define TEST_FP_CMP_OP_D TEST_FP_CMP_OP_D32
+#endif
+
+  TEST_FP_CMP_OP_D( 2, feq.d, 0x00, 1, -1.36, -1.36)
+  TEST_FP_CMP_OP_D( 3, fle.d, 0x00, 1, -1.36, -1.36)
+  TEST_FP_CMP_OP_D( 4, flt.d, 0x00, 0, -1.36, -1.36)
+
+  TEST_FP_CMP_OP_D( 5, feq.d, 0x00, 0, -1.37, -1.36)
+  TEST_FP_CMP_OP_D( 6, fle.d, 0x00, 1, -1.37, -1.36)
+  TEST_FP_CMP_OP_D( 7, flt.d, 0x00, 1, -1.37, -1.36)
+
+  # Only sNaN should signal invalid for feq.
+  TEST_FP_CMP_OP_D( 8, feq.d, 0x00, 0, NaN, 0)
+  TEST_FP_CMP_OP_D( 9, feq.d, 0x00, 0, NaN, NaN)
+  TEST_FP_CMP_OP_D(10, feq.d, 0x10, 0, sNaN, 0)
+
+  # qNaN should signal invalid for fle/flt.
+  TEST_FP_CMP_OP_D(11, flt.d, 0x10, 0, NaN, 0)
+  TEST_FP_CMP_OP_D(12, flt.d, 0x10, 0, NaN, NaN)
+  TEST_FP_CMP_OP_D(13, flt.d, 0x10, 0, sNaN, 0)
+  TEST_FP_CMP_OP_D(14, fle.d, 0x10, 0, NaN, 0)
+  TEST_FP_CMP_OP_D(15, fle.d, 0x10, 0, NaN, NaN)
+  TEST_FP_CMP_OP_D(16, fle.d, 0x10, 0, sNaN, 0)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fcvt.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fcvt.S
@@ -1,0 +1,64 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fcvt.S
+#-----------------------------------------------------------------------------
+#
+# Test fcvt.d.{wu|w|lu|l}, fcvt.s.d, and fcvt.d.s instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_INT_FP_OP_D
+    #define TEST_INT_FP_OP_D TEST_INT_FP_OP_D32
+
+    #undef TEST_FCVT_S_D
+    #define TEST_FCVT_S_D TEST_FCVT_S_D32
+#endif
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_INT_FP_OP_D(2,  fcvt.d.w,                   2.0,  2);
+  TEST_INT_FP_OP_D(3,  fcvt.d.w,                  -2.0, -2);
+
+  TEST_INT_FP_OP_D(4, fcvt.d.wu,                   2.0,  2);
+  #TEST_INT_FP_OP_D(5, fcvt.d.wu,            4294967294, -2);
+
+#if __riscv_xlen >= 64
+  #TEST_INT_FP_OP_D(6,  fcvt.d.l,                   2.0,  2);
+  #TEST_INT_FP_OP_D(7,  fcvt.d.l,                  -2.0, -2);
+
+  #TEST_INT_FP_OP_D(8, fcvt.d.lu,                   2.0,  2);
+  #TEST_INT_FP_OP_D(9, fcvt.d.lu, 1.8446744073709552e19, -2);
+#endif
+
+  #TEST_FCVT_S_D(10, -1.5, -1.5)
+  #TEST_FCVT_D_S(11, -1.5, -1.5)
+
+#if __riscv_xlen >= 64
+  #TEST_CASE(12, a0, 0x7ff8000000000000, la a1, test_data_22; ld a2, 0(a1); fmv.d.x f2, a2; fcvt.s.d f2, f2; fcvt.d.s f2, f2; fmv.x.d a0, f2; )
+#else
+  #TEST_CASE_D32(12, a0, a1, 0x7ff8000000000000, la a1, test_data_22; fld f2, 0(a1); fcvt.s.d f2, f2; fcvt.d.s f2, f2; fsd f2, 0(a1); lw a0, 0(a1); lw a1, 4(a1) )
+#endif
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+test_data_22:
+  .dword 0x7ffcffffffff8004
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fcvt_w.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fcvt_w.S
@@ -1,0 +1,114 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fcvt_w.S
+#-----------------------------------------------------------------------------
+#
+# Test fcvt{wu|w|lu|l}.d instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FP_INT_OP_D( 2,  fcvt.w.d, 0x01,         -1, -1.1, rtz);
+  TEST_FP_INT_OP_D( 3,  fcvt.w.d, 0x00,         -1, -1.0, rtz);
+  #TEST_FP_INT_OP_D( 4,  fcvt.w.d, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_D( 5,  fcvt.w.d, 0x01,          0,  0.9, rtz);
+  TEST_FP_INT_OP_D( 6,  fcvt.w.d, 0x00,          1,  1.0, rtz);
+  TEST_FP_INT_OP_D( 7,  fcvt.w.d, 0x01,          1,  1.1, rtz);
+  TEST_FP_INT_OP_D( 8,  fcvt.w.d, 0x10,     -1<<31, -3e9, rtz);
+  TEST_FP_INT_OP_D( 9,  fcvt.w.d, 0x10,  (1<<31)-1,  3e9, rtz);
+
+  TEST_FP_INT_OP_D(12, fcvt.wu.d, 0x10,          0, -3.0, rtz);
+  TEST_FP_INT_OP_D(13, fcvt.wu.d, 0x10,          0, -1.0, rtz);
+  #TEST_FP_INT_OP_D(14, fcvt.wu.d, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_D(15, fcvt.wu.d, 0x01,          0,  0.9, rtz);
+  TEST_FP_INT_OP_D(16, fcvt.wu.d, 0x00,          1,  1.0, rtz);
+  TEST_FP_INT_OP_D(17, fcvt.wu.d, 0x01,          1,  1.1, rtz);
+  TEST_FP_INT_OP_D(18, fcvt.wu.d, 0x10,          0, -3e9, rtz);
+  TEST_FP_INT_OP_D(19, fcvt.wu.d, 0x00, 0xffffffffb2d05e00, 3e9, rtz);
+
+#if __riscv_xlen >= 64
+  TEST_FP_INT_OP_D(22,  fcvt.l.d, 0x01,         -1, -1.1, rtz);
+  TEST_FP_INT_OP_D(23,  fcvt.l.d, 0x00,         -1, -1.0, rtz);
+  #TEST_FP_INT_OP_D(24,  fcvt.l.d, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_D(25,  fcvt.l.d, 0x01,          0,  0.9, rtz);
+  TEST_FP_INT_OP_D(26,  fcvt.l.d, 0x00,          1,  1.0, rtz);
+  TEST_FP_INT_OP_D(27,  fcvt.l.d, 0x01,          1,  1.1, rtz);
+  TEST_FP_INT_OP_D(28,  fcvt.l.d, 0x00,-3000000000, -3e9, rtz);
+  TEST_FP_INT_OP_D(29,  fcvt.l.d, 0x00, 3000000000,  3e9, rtz);
+  TEST_FP_INT_OP_D(20,  fcvt.l.d, 0x10,     -1<<63,-3e19, rtz);
+  TEST_FP_INT_OP_D(21,  fcvt.l.d, 0x10,  (1<<63)-1, 3e19, rtz);
+
+  TEST_FP_INT_OP_D(32, fcvt.lu.d, 0x10,          0, -3.0, rtz);
+  TEST_FP_INT_OP_D(33, fcvt.lu.d, 0x10,          0, -1.0, rtz);
+  #TEST_FP_INT_OP_D(34, fcvt.lu.d, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_D(35, fcvt.lu.d, 0x01,          0,  0.9, rtz);
+  #TEST_FP_INT_OP_D(36, fcvt.lu.d, 0x00,          1,  1.0, rtz);
+  TEST_FP_INT_OP_D(37, fcvt.lu.d, 0x01,          1,  1.1, rtz);
+  TEST_FP_INT_OP_D(38, fcvt.lu.d, 0x10,          0, -3e9, rtz);
+  TEST_FP_INT_OP_D(39, fcvt.lu.d, 0x00, 3000000000,  3e9, rtz);
+#endif
+
+  # test negative NaN, negative infinity conversion
+  TEST_CASE(42, x1, 0x000000007fffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE(43, x1, 0x7fffffffffffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.l.d x1, f1)
+#endif
+  TEST_CASE(44, x1, 0xffffffff80000000, la x1, tdat_d; fld f1, 16(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE(45, x1, 0x8000000000000000, la x1, tdat_d; fld f1, 16(x1); fcvt.l.d x1, f1)
+#endif
+
+  # test positive NaN, positive infinity conversion
+  TEST_CASE(52, x1, 0x000000007fffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE(53, x1, 0x7fffffffffffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.l.d x1, f1)
+#endif
+  TEST_CASE(54, x1, 0x000000007fffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE(55, x1, 0x7fffffffffffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.l.d x1, f1)
+#endif
+
+  # test NaN, infinity conversions to unsigned integer
+  TEST_CASE(62, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.wu.d x1, f1)
+  TEST_CASE(63, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.wu.d x1, f1)
+  TEST_CASE(64, x1,                  0, la x1, tdat_d; fld f1, 16(x1); fcvt.wu.d x1, f1)
+  TEST_CASE(65, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.wu.d x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE(66, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.lu.d x1, f1)
+  TEST_CASE(67, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.lu.d x1, f1)
+  TEST_CASE(68, x1,                  0, la x1, tdat_d; fld f1, 16(x1); fcvt.lu.d x1, f1)
+  TEST_CASE(69, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.lu.d x1, f1)
+#endif
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+# -NaN, NaN, -inf, +inf
+tdat:
+.word 0xffffffff
+.word 0x7fffffff
+.word 0xff800000
+.word 0x7f800000
+
+tdat_d:
+.dword 0xffffffffffffffff
+.dword 0x7fffffffffffffff
+.dword 0xfff0000000000000
+.dword 0x7ff0000000000000
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fdiv.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fdiv.S
@@ -1,0 +1,54 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fdiv.S
+#-----------------------------------------------------------------------------
+#
+# Test f{div|sqrt}.d instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+#if __riscv_xlen == 32
+    # Replace the functions with the 32-bit variants defined in test_macros.h
+    #undef TEST_FP_OP2_D
+    #define TEST_FP_OP2_D TEST_FP_OP2_D32
+
+    #undef TEST_FP_OP1_D
+    #define TEST_FP_OP1_D TEST_FP_OP1_D32
+
+    #undef TEST_FP_OP1_D_DWORD_RESULT
+    #define TEST_FP_OP1_D_DWORD_RESULT TEST_FP_OP1_D32_DWORD_RESULT
+#endif
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  #TEST_FP_OP2_D( 2,  fdiv.d, 1, 1.1557273520668288, 3.14159265, 2.71828182 );
+  #TEST_FP_OP2_D( 3,  fdiv.d, 1,-0.9991093838555584,      -1234,     1235.1 );
+  #TEST_FP_OP2_D( 4,  fdiv.d, 0,         3.14159265, 3.14159265,        1.0 );
+
+  #TEST_FP_OP1_D( 5,  fsqrt.d, 1, 1.7724538498928541, 3.14159265 );
+  #TEST_FP_OP1_D( 6,  fsqrt.d, 0,                100,      10000 );
+
+  #TEST_FP_OP1_D_DWORD_RESULT(16,  fsqrt.d, 0x10,      0x7FF8000000000000,      -1.0 );
+
+  #TEST_FP_OP1_D( 7,  fsqrt.d, 1, 13.076696830622021, 171.0);
+
+  #TEST_FP_OP1_D( 8,  fsqrt.d, 1,0.00040099251863345283320230749702, 1.60795e-7);
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fmadd.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fmadd.S
@@ -1,0 +1,51 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fmadd.S
+#-----------------------------------------------------------------------------
+#
+# Test f[n]m{add|sub}.s and f[n]m{add|sub}.d instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_OP3_D
+    #define TEST_FP_OP3_D TEST_FP_OP3_D32
+#endif
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FP_OP3_D( 2,  fmadd.d, 0,                 3.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_D( 3,  fmadd.d, 1,  1236.1999999999999, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_D( 4,  fmadd.d, 0,               -12.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_FP_OP3_D( 5, fnmadd.d, 0,                -3.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_D( 6, fnmadd.d, 1, -1236.1999999999999, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_D( 7, fnmadd.d, 0,                12.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_FP_OP3_D( 8,  fmsub.d, 0,                 1.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_D( 9,  fmsub.d, 1,                1234, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_D(10,  fmsub.d, 0,                -8.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_FP_OP3_D(11, fnmsub.d, 0,                -1.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_D(12, fnmsub.d, 1,               -1234, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_D(13, fnmsub.d, 0,                 8.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fmin.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-fmin.S
@@ -1,0 +1,60 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fmin.S
+#-----------------------------------------------------------------------------
+#
+# Test f{min|max}.d instructinos.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_OP2_D
+    #define TEST_FP_OP2_D TEST_FP_OP2_D32
+#endif
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FP_OP2_D( 2,  fmin.d, 0,        1.0,        2.5,        1.0 );
+  TEST_FP_OP2_D( 3,  fmin.d, 0,    -1235.1,    -1235.1,        1.1 );
+  TEST_FP_OP2_D( 4,  fmin.d, 0,    -1235.1,        1.1,    -1235.1 );
+  TEST_FP_OP2_D( 5,  fmin.d, 0,    -1235.1,        NaN,    -1235.1 );
+  TEST_FP_OP2_D( 6,  fmin.d, 0, 0.00000001, 3.14159265, 0.00000001 );
+  TEST_FP_OP2_D( 7,  fmin.d, 0,       -2.0,       -1.0,       -2.0 );
+
+  TEST_FP_OP2_D(12,  fmax.d, 0,        2.5,        2.5,        1.0 );
+  TEST_FP_OP2_D(13,  fmax.d, 0,        1.1,    -1235.1,        1.1 );
+  TEST_FP_OP2_D(14,  fmax.d, 0,        1.1,        1.1,    -1235.1 );
+  TEST_FP_OP2_D(15,  fmax.d, 0,    -1235.1,        NaN,    -1235.1 );
+  TEST_FP_OP2_D(16,  fmax.d, 0, 3.14159265, 3.14159265, 0.00000001 );
+  TEST_FP_OP2_D(17,  fmax.d, 0,       -1.0,       -1.0,       -2.0 );
+
+  # FMAX(sNaN, x) = x
+  TEST_FP_OP2_D(20,  fmax.d, 0x10, 1.0, sNaN, 1.0);
+  # FMAX(qNaN, qNaN) = canonical NaN
+  TEST_FP_OP2_D(21,  fmax.d, 0x00, qNaN, NaN, NaN);
+
+  # -0.0 < +0.0
+  TEST_FP_OP2_D(30,  fmin.d, 0,       -0.0,       -0.0,        0.0 );
+  TEST_FP_OP2_D(31,  fmin.d, 0,       -0.0,        0.0,       -0.0 );
+  TEST_FP_OP2_D(32,  fmax.d, 0,        0.0,       -0.0,        0.0 );
+  TEST_FP_OP2_D(33,  fmax.d, 0,        0.0,        0.0,       -0.0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-ldst.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-ldst.S
@@ -1,0 +1,42 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# ldst.S
+#-----------------------------------------------------------------------------
+#
+# This test verifies that flw, fld, fsw, and fsd work properly.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  la s0, tdat
+  TEST_CASE(2, a0, 0x40000000bf800000, fld f2, 0(s0); fsd f2, 16(s0); ld a0, 16(s0))
+  TEST_CASE(3, a0, 0x40000000bf800000, fld f2, 0(s0); fsw f2, 16(s0); ld a0, 16(s0))
+  TEST_CASE(4, a0, 0x40000000bf800000, flw f2, 0(s0); fsw f2, 16(s0); ld a0, 16(s0))
+  TEST_CASE(5, a0, 0xc080000040400000, fld f2, 8(s0); fsd f2, 16(s0); ld a0, 16(s0))
+  TEST_CASE(6, a0, 0xffffffff40400000, flw f2, 8(s0); fsd f2, 16(s0); ld a0, 16(s0))
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+.word 0xbf800000
+.word 0x40000000
+.word 0x40400000
+.word 0xc0800000
+.word 0xdeadbeef
+.word 0xcafebabe
+.word 0xabad1dea
+.word 0x1337d00d
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-move.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-move.S
@@ -1,0 +1,113 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# move.S
+#-----------------------------------------------------------------------------
+#
+# This test verifies that fmv.d.x, fmv.x.d, and fsgnj[x|n].d work properly.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+#TODO: make 32-bit compatible version
+#define TEST_FSGNJD(n, insn, new_sign, rs1_sign, rs2_sign) \
+  TEST_CASE(n, a0, 0x123456789abcdef0 | (-(new_sign) << 63), \
+    li a1, ((rs1_sign) << 63) | 0x123456789abcdef0; \
+    li a2, -(rs2_sign); \
+    fmv.d.x f1, a1; \
+    fmv.d.x f2, a2; \
+    insn f0, f1, f2; \
+    fmv.x.d a0, f0)
+
+  TEST_FSGNJD(10, fsgnj.d, 0, 0, 0)
+  TEST_FSGNJD(11, fsgnj.d, 1, 0, 1)
+  TEST_FSGNJD(12, fsgnj.d, 0, 1, 0)
+  TEST_FSGNJD(13, fsgnj.d, 1, 1, 1)
+
+  TEST_FSGNJD(20, fsgnjn.d, 1, 0, 0)
+  TEST_FSGNJD(21, fsgnjn.d, 0, 0, 1)
+  TEST_FSGNJD(22, fsgnjn.d, 1, 1, 0)
+  TEST_FSGNJD(23, fsgnjn.d, 0, 1, 1)
+
+  TEST_FSGNJD(30, fsgnjx.d, 0, 0, 0)
+  TEST_FSGNJD(31, fsgnjx.d, 1, 0, 1)
+  TEST_FSGNJD(32, fsgnjx.d, 1, 1, 0)
+  TEST_FSGNJD(33, fsgnjx.d, 0, 1, 1)
+
+// Test fsgnj.s in conjunction with double-precision moves
+#define TEST_FSGNJS(n, rd, rs1, rs2) \
+  TEST_CASE(n, a0, (rd) | (-((rd) >> 31) << 32), \
+    li a1, rs1; \
+    li a2, rs2; \
+    fmv.d.x f1, a1; \
+    fmv.d.x f2, a2; \
+    fsgnj.s f0, f1, f2; \
+    fmv.x.s a0, f0); \
+  TEST_CASE(1##n, a0, (rd) | 0xffffffff00000000, \
+    li a1, rs1; \
+    li a2, rs2; \
+    fmv.d.x f1, a1; \
+    fmv.d.x f2, a2; \
+    fsgnj.s f0, f1, f2; \
+    fmv.x.d a0, f0)
+
+  TEST_FSGNJS(40, 0x7fc00000, 0x7ffffffe12345678, 0)
+  TEST_FSGNJS(41, 0x7fc00000, 0xfffffffe12345678, 0)
+  TEST_FSGNJS(42, 0x7fc00000, 0x7fffffff12345678, 0)
+  TEST_FSGNJS(43, 0x12345678, 0xffffffff12345678, 0)
+
+  TEST_FSGNJS(50, 0x7fc00000, 0x7ffffffe12345678, 0x80000000)
+  TEST_FSGNJS(51, 0x7fc00000, 0xfffffffe12345678, 0x80000000)
+  TEST_FSGNJS(52, 0x7fc00000, 0x7fffffff12345678, 0x80000000)
+  TEST_FSGNJS(53, 0x12345678, 0xffffffff12345678, 0x80000000)
+
+  TEST_FSGNJS(60, 0xffc00000, 0x7ffffffe12345678, 0xffffffff80000000)
+  TEST_FSGNJS(61, 0xffc00000, 0xfffffffe12345678, 0xffffffff80000000)
+  TEST_FSGNJS(62, 0x92345678, 0xffffffff12345678, 0xffffffff80000000)
+  TEST_FSGNJS(63, 0x12345678, 0xffffffff12345678, 0x7fffffff80000000)
+
+// Test fsgnj.d in conjunction with single-precision moves
+#define TEST_FSGNJD_SP(n, isnan, rd, rs1, rs2) \
+  TEST_CASE(n, a0, ((rd) & 0xffffffff) | (-(((rd) >> 31) & 1) << 32), \
+    li a1, rs1; \
+    li a2, rs2; \
+    fmv.d.x f1, a1; \
+    fmv.d.x f2, a2; \
+    fsgnj.d f0, f1, f2; \
+    feq.s a0, f0, f0; \
+    addi a0, a0, -!(isnan); \
+    bnez a0, 1f; \
+    fmv.x.s a0, f0; \
+    1:); \
+  TEST_CASE(1##n, a0, rd, \
+    li a1, rs1; \
+    li a2, rs2; \
+    fmv.d.x f1, a1; \
+    fmv.d.x f2, a2; \
+    fsgnj.d f0, f1, f2; \
+    fmv.x.d a0, f0; \
+    1:)
+
+  TEST_FSGNJD_SP(70, 0, 0xffffffff11111111, 0xffffffff11111111, 0xffffffff11111111)
+  TEST_FSGNJD_SP(71, 1, 0x7fffffff11111111, 0xffffffff11111111, 0x7fffffff11111111)
+  TEST_FSGNJD_SP(72, 0, 0xffffffff11111111, 0xffffffff11111111, 0xffffffff91111111)
+  TEST_FSGNJD_SP(73, 0, 0xffffffff11111111, 0xffffffff11111111, 0x8000000000000000)
+  TEST_FSGNJD_SP(74, 0, 0xffffffff11111111, 0x7fffffff11111111, 0xffffffff11111111)
+  TEST_FSGNJD_SP(75, 1, 0x7fffffff11111111, 0x7fffffff11111111, 0x7fffffff11111111)
+  TEST_FSGNJD_SP(76, 0, 0xffffffff11111111, 0x7fffffff11111111, 0xffffffff91111111)
+  TEST_FSGNJD_SP(77, 0, 0xffffffff11111111, 0x7fffffff11111111, 0x8000000000000000)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-recoding.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-recoding.S
@@ -1,0 +1,67 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# recoding.S
+#-----------------------------------------------------------------------------
+#
+# Test corner cases of John Hauser's microarchitectural recoding scheme.
+# There are twice as many recoded values as IEEE-754 values; some of these
+# extras are redundant (e.g. Inf) and others are illegal (subnormals with
+# too many bits set).
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  # Make sure infinities with different mantissas compare as equal.
+  fld f0, minf, a0
+  fld f1, three, a0
+  fmul.d f1, f1, f0
+  TEST_CASE( 2, a0, 1, feq.d a0, f0, f1)
+  TEST_CASE( 3, a0, 1, fle.d a0, f0, f1)
+  TEST_CASE( 4, a0, 0, flt.d a0, f0, f1)
+
+  # Likewise, but for zeroes.
+  fcvt.d.w f0, x0
+  li a0, 1
+  fcvt.d.w f1, a0
+  fmul.d f1, f1, f0
+  TEST_CASE(5, a0, 1, feq.d a0, f0, f1)
+  TEST_CASE(6, a0, 1, fle.d a0, f0, f1)
+  TEST_CASE(7, a0, 0, flt.d a0, f0, f1)
+
+  # When converting small doubles to single-precision subnormals,
+  # ensure that the extra precision is discarded.
+  flw f0, big, a0
+  fld f1, tiny, a0
+  fcvt.s.d f1, f1
+  fmul.s f0, f0, f1
+  fmv.x.s a0, f0
+  lw a1, small
+  TEST_CASE(10, a0, 0, sub a0, a0, a1)
+
+  # Make sure FSD+FLD correctly saves and restores a single-precision value.
+  flw f0, three, a0
+  fadd.s f1, f0, f0
+  fadd.s f0, f0, f0
+  fsd f0, tiny, a0
+  fld f0, tiny, a0
+  TEST_CASE(20, a0, 1, feq.s a0, f0, f1)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+minf: .double -Inf
+three: .double 3.0
+big: .float 1221
+small: .float 2.9133121e-37
+tiny: .double 2.3860049081905093e-40
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-structural.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ud-p-structural.S
@@ -1,0 +1,60 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# structural.S
+#-----------------------------------------------------------------------------
+#
+# This test verifies that the FPU correctly obviates structural hazards on its
+# writeback port (e.g. fadd followed by fsgnj)
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+li x12, 1
+
+li x2, 0x3FF0000000000000
+li x1, 0x3F800000
+
+#define TEST(testnum, nops)     \
+test_ ## testnum: \
+  li  TESTNUM, testnum; \
+  fmv.d.x  f4, x0    ;\
+  fmv.s.x  f3, x0    ;\
+  fmv.d.x  f2, x2    ;\
+  fmv.s.x  f1, x1    ;\
+  j 1f ;\
+  .align 5        ;\
+1:fmul.d  f4, f2, f2  ;\
+  nops          ;\
+  fsgnj.s f3, f1, f1 ;\
+  fmv.x.d  x4, f4    ;\
+  fmv.x.s  x5, f3    ;\
+  beq     x1, x5, 2f  ;\
+  j fail;\
+2:beq     x2, x4, 2f  ;\
+  j fail; \
+2:fmv.d.x  f2, zero    ;\
+  fmv.s.x  f1, zero    ;\
+
+TEST(1,;)
+TEST(2,nop)
+TEST(3,nop;nop)
+TEST(4,nop;nop;nop)
+TEST(5,nop;nop;nop;nop)
+TEST(6,nop;nop;nop;nop;nop)
+TEST(7,nop;nop;nop;nop;nop;nop)
+
+TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fadd.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fadd.S
@@ -1,0 +1,44 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fadd.S
+#-----------------------------------------------------------------------------
+#
+# Test f{add|sub|mul}.s instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  #TEST_FP_OP2_S( 2,  fadd.s, 0,                3.5,        2.5,        1.0 );
+  #TEST_FP_OP2_S( 3,  fadd.s, 1,              -1234,    -1235.1,        1.1 );
+  #TEST_FP_OP2_S( 4,  fadd.s, 1,         3.14159265, 3.14159265, 0.00000001 );
+
+  #TEST_FP_OP2_S( 5,  fsub.s, 0,                1.5,        2.5,        1.0 );
+  #TEST_FP_OP2_S( 6,  fsub.s, 1,              -1234,    -1235.1,       -1.1 );
+  #TEST_FP_OP2_S( 7,  fsub.s, 1,         3.14159265, 3.14159265, 0.00000001 );
+
+  #TEST_FP_OP2_S( 8,  fmul.s, 0,                2.5,        2.5,        1.0 );
+  #TEST_FP_OP2_S( 9,  fmul.s, 1,            1358.61,    -1235.1,       -1.1 );
+  #TEST_FP_OP2_S(10,  fmul.s, 1,      3.14159265e-8, 3.14159265, 0.00000001 );
+
+  # Is the canonical NaN generated for Inf - Inf?
+  #TEST_FP_OP2_S(11,  fsub.s, 0x10, qNaNf, Inf, Inf);
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fclass.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fclass.S
@@ -1,0 +1,40 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fclass.S
+#-----------------------------------------------------------------------------
+#
+# Test fclass.s instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FCLASS_S( 2, 1 << 0, 0xff800000 )
+  TEST_FCLASS_S( 3, 1 << 1, 0xbf800000 )
+  TEST_FCLASS_S( 4, 1 << 2, 0x807fffff )
+  TEST_FCLASS_S( 5, 1 << 3, 0x80000000 )
+  TEST_FCLASS_S( 6, 1 << 4, 0x00000000 )
+  TEST_FCLASS_S( 7, 1 << 5, 0x007fffff )
+  TEST_FCLASS_S( 8, 1 << 6, 0x3f800000 )
+  TEST_FCLASS_S( 9, 1 << 7, 0x7f800000 )
+  TEST_FCLASS_S(10, 1 << 8, 0x7f800001 )
+  TEST_FCLASS_S(11, 1 << 9, 0x7fc00000 )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fcmp.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fcmp.S
@@ -1,0 +1,50 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fcmp.S
+#-----------------------------------------------------------------------------
+#
+# Test f{eq|lt|le}.s instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FP_CMP_OP_S( 2, feq.s, 0x00, 1, -1.36, -1.36)
+  TEST_FP_CMP_OP_S( 3, fle.s, 0x00, 1, -1.36, -1.36)
+  TEST_FP_CMP_OP_S( 4, flt.s, 0x00, 0, -1.36, -1.36)
+
+  TEST_FP_CMP_OP_S( 5, feq.s, 0x00, 0, -1.37, -1.36)
+  TEST_FP_CMP_OP_S( 6, fle.s, 0x00, 1, -1.37, -1.36)
+  TEST_FP_CMP_OP_S( 7, flt.s, 0x00, 1, -1.37, -1.36)
+
+  # Only sNaN should signal invalid for feq.
+  TEST_FP_CMP_OP_S( 8, feq.s, 0x00, 0, NaN, 0)
+  TEST_FP_CMP_OP_S( 9, feq.s, 0x00, 0, NaN, NaN)
+  #TEST_FP_CMP_OP_S(10, feq.s, 0x10, 0, sNaNf, 0)
+
+  # qNaN should signal invalid for fle/flt.
+  TEST_FP_CMP_OP_S(11, flt.s, 0x10, 0, NaN, 0)
+  TEST_FP_CMP_OP_S(12, flt.s, 0x10, 0, NaN, NaN)
+  TEST_FP_CMP_OP_S(13, flt.s, 0x10, 0, sNaNf, 0)
+  TEST_FP_CMP_OP_S(14, fle.s, 0x10, 0, NaN, 0)
+  TEST_FP_CMP_OP_S(15, fle.s, 0x10, 0, NaN, NaN)
+  TEST_FP_CMP_OP_S(16, fle.s, 0x10, 0, sNaNf, 0)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fcvt.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fcvt.S
@@ -1,0 +1,43 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fcvt.S
+#-----------------------------------------------------------------------------
+#
+# Test fcvt.s.{wu|w|lu|l}, fcvt.s.d, and fcvt.d.s instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_INT_FP_OP_S( 2,  fcvt.s.w,                   2.0,  2);
+  #TEST_INT_FP_OP_S( 3,  fcvt.s.w,                  -2.0, -2);
+
+  TEST_INT_FP_OP_S( 4, fcvt.s.wu,                   2.0,  2);
+  TEST_INT_FP_OP_S( 5, fcvt.s.wu,           4.2949673e9, -2);
+
+#if __riscv_xlen >= 64
+  TEST_INT_FP_OP_S( 6,  fcvt.s.l,                   2.0,  2);
+  #TEST_INT_FP_OP_S( 7,  fcvt.s.l,                  -2.0, -2);
+
+  TEST_INT_FP_OP_S( 8, fcvt.s.lu,                   2.0,  2);
+  TEST_INT_FP_OP_S( 9, fcvt.s.lu,          1.8446744e19, -2);
+#endif
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fcvt_w.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fcvt_w.S
@@ -1,0 +1,105 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fcvt_w.S
+#-----------------------------------------------------------------------------
+#
+# Test fcvt{wu|w|lu|l}.s instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FP_INT_OP_S( 2,  fcvt.w.s, 0x01,         -1, -1.1, rtz);
+  TEST_FP_INT_OP_S( 3,  fcvt.w.s, 0x00,         -1, -1.0, rtz);
+  #TEST_FP_INT_OP_S( 4,  fcvt.w.s, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_S( 5,  fcvt.w.s, 0x01,          0,  0.9, rtz);
+  #TEST_FP_INT_OP_S( 6,  fcvt.w.s, 0x00,          1,  1.0, rtz);
+  #TEST_FP_INT_OP_S( 7,  fcvt.w.s, 0x01,          1,  1.1, rtz);
+  TEST_FP_INT_OP_S( 8,  fcvt.w.s, 0x10,     -1<<31, -3e9, rtz);
+  TEST_FP_INT_OP_S( 9,  fcvt.w.s, 0x10,  (1<<31)-1,  3e9, rtz);
+
+  TEST_FP_INT_OP_S(12, fcvt.wu.s, 0x10,          0, -3.0, rtz);
+  TEST_FP_INT_OP_S(13, fcvt.wu.s, 0x10,          0, -1.0, rtz);
+  #TEST_FP_INT_OP_S(14, fcvt.wu.s, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_S(15, fcvt.wu.s, 0x01,          0,  0.9, rtz);
+  #TEST_FP_INT_OP_S(16, fcvt.wu.s, 0x00,          1,  1.0, rtz);
+  #TEST_FP_INT_OP_S(17, fcvt.wu.s, 0x01,          1,  1.1, rtz);
+  TEST_FP_INT_OP_S(18, fcvt.wu.s, 0x10,          0, -3e9, rtz);
+  #TEST_FP_INT_OP_S(19, fcvt.wu.s, 0x00, 3000000000,  3e9, rtz);
+
+  #if __riscv_xlen >= 64
+  TEST_FP_INT_OP_S(22,  fcvt.l.s, 0x01,         -1, -1.1, rtz);
+  TEST_FP_INT_OP_S(23,  fcvt.l.s, 0x00,         -1, -1.0, rtz);
+  #TEST_FP_INT_OP_S(24,  fcvt.l.s, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_S(25,  fcvt.l.s, 0x01,          0,  0.9, rtz);
+  #TEST_FP_INT_OP_S(26,  fcvt.l.s, 0x00,          1,  1.0, rtz);
+  #TEST_FP_INT_OP_S(27,  fcvt.l.s, 0x01,          1,  1.1, rtz);
+
+  TEST_FP_INT_OP_S(32, fcvt.lu.s, 0x10,          0, -3.0, rtz);
+  TEST_FP_INT_OP_S(33, fcvt.lu.s, 0x10,          0, -1.0, rtz);
+  #TEST_FP_INT_OP_S(34, fcvt.lu.s, 0x01,          0, -0.9, rtz);
+  #TEST_FP_INT_OP_S(35, fcvt.lu.s, 0x01,          0,  0.9, rtz);
+  #TEST_FP_INT_OP_S(36, fcvt.lu.s, 0x00,          1,  1.0, rtz);
+  #TEST_FP_INT_OP_S(37, fcvt.lu.s, 0x01,          1,  1.1, rtz);
+  TEST_FP_INT_OP_S(38, fcvt.lu.s, 0x10,          0, -3e9, rtz);
+#endif
+
+  # test negative NaN, negative infinity conversion
+  TEST_CASE( 42, x1, 0x000000007fffffff, la x1, tdat  ; flw f1,  0(x1); fcvt.w.s x1, f1)
+  TEST_CASE( 44, x1, 0xffffffff80000000, la x1, tdat  ; flw f1,  8(x1); fcvt.w.s x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE( 43, x1, 0x7fffffffffffffff, la x1, tdat  ; flw f1,  0(x1); fcvt.l.s x1, f1)
+  TEST_CASE( 45, x1, 0x8000000000000000, la x1, tdat  ; flw f1,  8(x1); fcvt.l.s x1, f1)
+#endif
+
+  # test positive NaN, positive infinity conversion
+  TEST_CASE( 52, x1, 0x000000007fffffff, la x1, tdat  ; flw f1,  4(x1); fcvt.w.s x1, f1)
+  TEST_CASE( 54, x1, 0x000000007fffffff, la x1, tdat  ; flw f1, 12(x1); fcvt.w.s x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE( 53, x1, 0x7fffffffffffffff, la x1, tdat  ; flw f1,  4(x1); fcvt.l.s x1, f1)
+  TEST_CASE( 55, x1, 0x7fffffffffffffff, la x1, tdat  ; flw f1, 12(x1); fcvt.l.s x1, f1)
+#endif
+
+  # test NaN, infinity conversions to unsigned integer
+  TEST_CASE( 62, x1, 0xffffffffffffffff, la x1, tdat  ; flw f1,  0(x1); fcvt.wu.s x1, f1)
+  TEST_CASE( 63, x1, 0xffffffffffffffff, la x1, tdat  ; flw f1,  4(x1); fcvt.wu.s x1, f1)
+  TEST_CASE( 64, x1,                  0, la x1, tdat  ; flw f1,  8(x1); fcvt.wu.s x1, f1)
+  TEST_CASE( 65, x1, 0xffffffffffffffff, la x1, tdat  ; flw f1, 12(x1); fcvt.wu.s x1, f1)
+#if __riscv_xlen >= 64
+  TEST_CASE( 66, x1, 0xffffffffffffffff, la x1, tdat  ; flw f1,  0(x1); fcvt.lu.s x1, f1)
+  TEST_CASE( 67, x1, 0xffffffffffffffff, la x1, tdat  ; flw f1,  4(x1); fcvt.lu.s x1, f1)
+  TEST_CASE( 68, x1,                  0, la x1, tdat  ; flw f1,  8(x1); fcvt.lu.s x1, f1)
+  TEST_CASE( 69, x1, 0xffffffffffffffff, la x1, tdat  ; flw f1, 12(x1); fcvt.lu.s x1, f1)
+#endif
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+# -NaN, NaN, -inf, +inf
+tdat:
+.word 0xffffffff
+.word 0x7fffffff
+.word 0xff800000
+.word 0x7f800000
+
+tdat_d:
+.dword 0xffffffffffffffff
+.dword 0x7fffffffffffffff
+.dword 0xfff0000000000000
+.dword 0x7ff0000000000000
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fdiv.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fdiv.S
@@ -1,0 +1,40 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fdiv.S
+#-----------------------------------------------------------------------------
+#
+# Test f{div|sqrt}.s instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  #TEST_FP_OP2_S(2,  fdiv.s, 1, 1.1557273520668288, 3.14159265, 2.71828182 );
+  #TEST_FP_OP2_S(3,  fdiv.s, 1,-0.9991093838555584,      -1234,     1235.1 );
+  #TEST_FP_OP2_S(4,  fdiv.s, 0,         3.14159265, 3.14159265,        1.0 );
+
+  #TEST_FP_OP1_S(5,  fsqrt.s, 1, 1.7724538498928541, 3.14159265 );
+  #TEST_FP_OP1_S(6,  fsqrt.s, 0,                100,      10000 );
+
+  #TEST_FP_OP1_S_DWORD_RESULT(7,  fsqrt.s, 0x10, 0x7FC00000, -1.0 );
+
+  #TEST_FP_OP1_S(8,  fsqrt.s, 1, 13.076696, 171.0);
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fmadd.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fmadd.S
@@ -1,0 +1,45 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fmadd.S
+#-----------------------------------------------------------------------------
+#
+# Test f[n]m{add|sub}.s and f[n]m{add|sub}.d instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_FP_OP3_S( 2,  fmadd.s, 0,                 3.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_S( 3,  fmadd.s, 1,              1236.2, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_S( 4,  fmadd.s, 0,               -12.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_FP_OP3_S( 5, fnmadd.s, 0,                -3.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_S( 6, fnmadd.s, 1,             -1236.2, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_S( 7, fnmadd.s, 0,                12.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_FP_OP3_S( 8,  fmsub.s, 0,                 1.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_S( 9,  fmsub.s, 1,                1234, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_S(10,  fmsub.s, 0,                -8.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_FP_OP3_S(11, fnmsub.s, 0,                -1.5,  1.0,        2.5,        1.0 );
+  TEST_FP_OP3_S(12, fnmsub.s, 1,               -1234, -1.0,    -1235.1,        1.1 );
+  TEST_FP_OP3_S(13, fnmsub.s, 0,                 8.0,  2.0,       -5.0,       -2.0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fmin.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-fmin.S
@@ -1,0 +1,54 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fmin.S
+#-----------------------------------------------------------------------------
+#
+# Test f{min|max}.s instructinos.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  #TEST_FP_OP2_S( 2,  fmin.s, 0,        1.0,        2.5,        1.0 );
+  #TEST_FP_OP2_S( 3,  fmin.s, 0,    -1235.1,    -1235.1,        1.1 );
+  #TEST_FP_OP2_S( 4,  fmin.s, 0,    -1235.1,        1.1,    -1235.1 );
+  #TEST_FP_OP2_S( 5,  fmin.s, 0,    -1235.1,        NaN,    -1235.1 );
+  #TEST_FP_OP2_S( 6,  fmin.s, 0, 0.00000001, 3.14159265, 0.00000001 );
+  #TEST_FP_OP2_S( 7,  fmin.s, 0,       -2.0,       -1.0,       -2.0 );
+
+  #TEST_FP_OP2_S(12,  fmax.s, 0,        2.5,        2.5,        1.0 );
+  #TEST_FP_OP2_S(13,  fmax.s, 0,        1.1,    -1235.1,        1.1 );
+  #TEST_FP_OP2_S(14,  fmax.s, 0,        1.1,        1.1,    -1235.1 );
+  #TEST_FP_OP2_S(15,  fmax.s, 0,    -1235.1,        NaN,    -1235.1 );
+  #TEST_FP_OP2_S(16,  fmax.s, 0, 3.14159265, 3.14159265, 0.00000001 );
+  #TEST_FP_OP2_S(17,  fmax.s, 0,       -1.0,       -1.0,       -2.0 );
+
+  # FMAX(sNaN, x) = x
+  #TEST_FP_OP2_S(20,  fmax.s, 0x10, 1.0, sNaNf, 1.0);
+  # FMAX(qNaN, qNaN) = canonical NaN
+  #TEST_FP_OP2_S(21,  fmax.s, 0x00, qNaNf, NaN, NaN);
+
+  # -0.0 < +0.0
+  #TEST_FP_OP2_S(30,  fmin.s, 0,       -0.0,       -0.0,        0.0 );
+  #TEST_FP_OP2_S(31,  fmin.s, 0,       -0.0,        0.0,       -0.0 );
+  #TEST_FP_OP2_S(32,  fmax.s, 0,        0.0,       -0.0,        0.0 );
+  #TEST_FP_OP2_S(33,  fmax.s, 0,        0.0,        0.0,       -0.0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-ldst.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-ldst.S
@@ -1,0 +1,38 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# ldst.S
+#-----------------------------------------------------------------------------
+#
+# This test verifies that flw, fld, fsw, and fsd work properly.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(2, a0, 0x40000000deadbeef, la a1, tdat; flw f1, 4(a1); fsw f1, 20(a1); ld a0, 16(a1))
+  TEST_CASE(3, a0, 0x1337d00dbf800000, la a1, tdat; flw f1, 0(a1); fsw f1, 24(a1); ld a0, 24(a1))
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+.word 0xbf800000
+.word 0x40000000
+.word 0x40400000
+.word 0xc0800000
+.word 0xdeadbeef
+.word 0xcafebabe
+.word 0xabad1dea
+.word 0x1337d00d
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-move.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-move.S
@@ -1,0 +1,58 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# move.S
+#-----------------------------------------------------------------------------
+#
+# This test verifies that the fmv.s.x, fmv.x.s, and fsgnj[x|n].d instructions
+# and the fcsr work properly.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(2, a1, 1, csrwi fcsr, 1; li a0, 0x1234; fssr a1, a0)
+  TEST_CASE(3, a0, 0x34, frsr a0)
+  TEST_CASE(4, a0, 0x14, frflags a0)
+  TEST_CASE(5, a0, 0x01, csrrwi a0, frm, 2)
+  TEST_CASE(6, a0, 0x54, frsr a0)
+  TEST_CASE(7, a0, 0x14, csrrci a0, fflags, 4)
+  TEST_CASE(8, a0, 0x50, frsr a0)
+
+#define TEST_FSGNJS(n, insn, new_sign, rs1_sign, rs2_sign) \
+  TEST_CASE(n, a0, 0x12345678 | (-(new_sign) << 31), \
+    li a1, ((rs1_sign) << 31) | 0x12345678; \
+    li a2, -(rs2_sign); \
+    fmv.s.x f1, a1; \
+    fmv.s.x f2, a2; \
+    insn f0, f1, f2; \
+    fmv.x.s a0, f0)
+
+  TEST_FSGNJS(10, fsgnj.s, 0, 0, 0)
+  TEST_FSGNJS(11, fsgnj.s, 1, 0, 1)
+  TEST_FSGNJS(12, fsgnj.s, 0, 1, 0)
+  TEST_FSGNJS(13, fsgnj.s, 1, 1, 1)
+
+  TEST_FSGNJS(20, fsgnjn.s, 1, 0, 0)
+  TEST_FSGNJS(21, fsgnjn.s, 0, 0, 1)
+  TEST_FSGNJS(22, fsgnjn.s, 1, 1, 0)
+  TEST_FSGNJS(23, fsgnjn.s, 0, 1, 1)
+
+  TEST_FSGNJS(30, fsgnjx.s, 0, 0, 0)
+  TEST_FSGNJS(31, fsgnjx.s, 1, 0, 1)
+  TEST_FSGNJS(32, fsgnjx.s, 1, 1, 0)
+  TEST_FSGNJS(33, fsgnjx.s, 0, 1, 1)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-recoding.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64uf-p-recoding.S
@@ -1,0 +1,46 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# recoding.S
+#-----------------------------------------------------------------------------
+#
+# Test corner cases of John Hauser's microarchitectural recoding scheme.
+# There are twice as many recoded values as IEEE-754 values; some of these
+# extras are redundant (e.g. Inf) and others are illegal (subnormals with
+# too many bits set).
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64UF
+RVTEST_CODE_BEGIN
+
+  # Make sure infinities with different mantissas compare as equal.
+  flw f0, minf, a0
+  flw f1, three, a0
+  fmul.s f1, f1, f0
+  TEST_CASE( 2, a0, 1, feq.s a0, f0, f1)
+  TEST_CASE( 3, a0, 1, fle.s a0, f0, f1)
+  TEST_CASE( 4, a0, 0, flt.s a0, f0, f1)
+
+  # Likewise, but for zeroes.
+  fcvt.s.w f0, x0
+  li a0, 1
+  fcvt.s.w f1, a0
+  fmul.s f1, f1, f0
+  TEST_CASE(5, a0, 1, feq.s a0, f0, f1)
+  TEST_CASE(6, a0, 1, fle.s a0, f0, f1)
+  TEST_CASE(7, a0, 0, flt.s a0, f0, f1)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+minf: .float -Inf
+three: .float 3.0
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-add.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-add.S
@@ -1,0 +1,85 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# add.S
+#-----------------------------------------------------------------------------
+#
+# Test add instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  add, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  add, 0x00000002, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  add, 0x0000000a, 0x00000003, 0x00000007 );
+
+  TEST_RR_OP( 5,  add, 0xffffffffffff8000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  add, 0xffffffff80000000, 0xffffffff80000000, 0x00000000 );
+  TEST_RR_OP( 7,  add, 0xffffffff7fff8000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 8,  add, 0x0000000000007fff, 0x0000000000000000, 0x0000000000007fff );
+  TEST_RR_OP( 9,  add, 0x000000007fffffff, 0x000000007fffffff, 0x0000000000000000 );
+  TEST_RR_OP( 10, add, 0x0000000080007ffe, 0x000000007fffffff, 0x0000000000007fff );
+
+  TEST_RR_OP( 11, add, 0xffffffff80007fff, 0xffffffff80000000, 0x0000000000007fff );
+  TEST_RR_OP( 12, add, 0x000000007fff7fff, 0x000000007fffffff, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 13, add, 0xffffffffffffffff, 0x0000000000000000, 0xffffffffffffffff );
+  TEST_RR_OP( 14, add, 0x0000000000000000, 0xffffffffffffffff, 0x0000000000000001 );
+  TEST_RR_OP( 15, add, 0xfffffffffffffffe, 0xffffffffffffffff, 0xffffffffffffffff );
+
+  TEST_RR_OP( 16, add, 0x0000000080000000, 0x0000000000000001, 0x000000007fffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 17, add, 24, 13, 11 );
+  TEST_RR_SRC2_EQ_DEST( 18, add, 25, 14, 11 );
+  TEST_RR_SRC12_EQ_DEST( 19, add, 26, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 20, 0, add, 24, 13, 11 );
+  TEST_RR_DEST_BYPASS( 21, 1, add, 25, 14, 11 );
+  TEST_RR_DEST_BYPASS( 22, 2, add, 26, 15, 11 );
+
+  TEST_RR_SRC12_BYPASS( 23, 0, 0, add, 24, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 1, add, 25, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 25, 0, 2, add, 26, 15, 11 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 0, add, 24, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 27, 1, 1, add, 25, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 28, 2, 0, add, 26, 15, 11 );
+
+  TEST_RR_SRC21_BYPASS( 29, 0, 0, add, 24, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 1, add, 25, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 31, 0, 2, add, 26, 15, 11 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 0, add, 24, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 33, 1, 1, add, 25, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 34, 2, 0, add, 26, 15, 11 );
+
+  TEST_RR_ZEROSRC1( 35, add, 15, 15 );
+  TEST_RR_ZEROSRC2( 36, add, 32, 32 );
+  TEST_RR_ZEROSRC12( 37, add, 0 );
+  TEST_RR_ZERODEST( 38, add, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-addi.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-addi.S
@@ -1,0 +1,71 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# addi.S
+#-----------------------------------------------------------------------------
+#
+# Test addi instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  addi, 0x00000000, 0x00000000, 0x000 );
+  TEST_IMM_OP( 3,  addi, 0x00000002, 0x00000001, 0x001 );
+  TEST_IMM_OP( 4,  addi, 0x0000000a, 0x00000003, 0x007 );
+
+  TEST_IMM_OP( 5,  addi, 0xfffffffffffff800, 0x0000000000000000, 0x800 );
+  TEST_IMM_OP( 6,  addi, 0xffffffff80000000, 0xffffffff80000000, 0x000 );
+  TEST_IMM_OP( 7,  addi, 0xffffffff7ffff800, 0xffffffff80000000, 0x800 );
+
+  TEST_IMM_OP( 8,  addi, 0x00000000000007ff, 0x00000000, 0x7ff );
+  TEST_IMM_OP( 9,  addi, 0x000000007fffffff, 0x7fffffff, 0x000 );
+  TEST_IMM_OP( 10, addi, 0x00000000800007fe, 0x7fffffff, 0x7ff );
+
+  TEST_IMM_OP( 11, addi, 0xffffffff800007ff, 0xffffffff80000000, 0x7ff );
+  TEST_IMM_OP( 12, addi, 0x000000007ffff7ff, 0x000000007fffffff, 0x800 );
+
+  TEST_IMM_OP( 13, addi, 0xffffffffffffffff, 0x0000000000000000, 0xfff );
+  TEST_IMM_OP( 14, addi, 0x0000000000000000, 0xffffffffffffffff, 0x001 );
+  TEST_IMM_OP( 15, addi, 0xfffffffffffffffe, 0xffffffffffffffff, 0xfff );
+
+  TEST_IMM_OP( 16, addi, 0x0000000080000000, 0x7fffffff, 0x001 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, addi, 24, 13, 11 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, addi, 24, 13, 11 );
+  TEST_IMM_DEST_BYPASS( 19, 1, addi, 23, 13, 10 );
+  TEST_IMM_DEST_BYPASS( 20, 2, addi, 22, 13,  9 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, addi, 24, 13, 11 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, addi, 23, 13, 10 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, addi, 22, 13,  9 );
+
+  TEST_IMM_ZEROSRC1( 24, addi, 32, 32 );
+  TEST_IMM_ZERODEST( 25, addi, 33, 50 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-addiw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-addiw.S
@@ -1,0 +1,71 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# addiw.S
+#-----------------------------------------------------------------------------
+#
+# Test addiw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  addiw, 0x00000000, 0x00000000, 0x000 );
+  TEST_IMM_OP( 3,  addiw, 0x00000002, 0x00000001, 0x001 );
+  TEST_IMM_OP( 4,  addiw, 0x0000000a, 0x00000003, 0x007 );
+
+  TEST_IMM_OP( 5,  addiw, 0xfffffffffffff800, 0x0000000000000000, 0x800 );
+  TEST_IMM_OP( 6,  addiw, 0xffffffff80000000, 0xffffffff80000000, 0x000 );
+  TEST_IMM_OP( 7,  addiw, 0x000000007ffff800, 0xffffffff80000000, 0x800 );
+
+  TEST_IMM_OP( 8,  addiw, 0x00000000000007ff, 0x00000000, 0x7ff );
+  TEST_IMM_OP( 9,  addiw, 0x000000007fffffff, 0x7fffffff, 0x000 );
+  TEST_IMM_OP( 10, addiw, 0xffffffff800007fe, 0x7fffffff, 0x7ff );
+
+  TEST_IMM_OP( 11, addiw, 0xffffffff800007ff, 0xffffffff80000000, 0x7ff );
+  TEST_IMM_OP( 12, addiw, 0x000000007ffff7ff, 0x000000007fffffff, 0x800 );
+
+  TEST_IMM_OP( 13, addiw, 0xffffffffffffffff, 0x0000000000000000, 0xfff );
+  TEST_IMM_OP( 14, addiw, 0x0000000000000000, 0xffffffffffffffff, 0x001 );
+  TEST_IMM_OP( 15, addiw, 0xfffffffffffffffe, 0xffffffffffffffff, 0xfff );
+
+  TEST_IMM_OP( 16, addiw, 0xffffffff80000000, 0x7fffffff, 0x001 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, addiw, 24, 13, 11 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, addiw, 24, 13, 11 );
+  TEST_IMM_DEST_BYPASS( 19, 1, addiw, 23, 13, 10 );
+  TEST_IMM_DEST_BYPASS( 20, 2, addiw, 22, 13,  9 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, addiw, 24, 13, 11 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, addiw, 23, 13, 10 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, addiw, 22, 13,  9 );
+
+  TEST_IMM_ZEROSRC1( 24, addiw, 32, 32 );
+  TEST_IMM_ZERODEST( 25, addiw, 33, 50 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-addw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-addw.S
@@ -1,0 +1,85 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# addw.S
+#-----------------------------------------------------------------------------
+#
+# Test addw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  addw, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  addw, 0x00000002, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  addw, 0x0000000a, 0x00000003, 0x00000007 );
+
+  TEST_RR_OP( 5,  addw, 0xffffffffffff8000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  addw, 0xffffffff80000000, 0xffffffff80000000, 0x00000000 );
+  TEST_RR_OP( 7,  addw, 0x000000007fff8000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 8,  addw, 0x0000000000007fff, 0x0000000000000000, 0x0000000000007fff );
+  TEST_RR_OP( 9,  addw, 0x000000007fffffff, 0x000000007fffffff, 0x0000000000000000 );
+  TEST_RR_OP( 10, addw, 0xffffffff80007ffe, 0x000000007fffffff, 0x0000000000007fff );
+
+  TEST_RR_OP( 11, addw, 0xffffffff80007fff, 0xffffffff80000000, 0x0000000000007fff );
+  TEST_RR_OP( 12, addw, 0x000000007fff7fff, 0x000000007fffffff, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 13, addw, 0xffffffffffffffff, 0x0000000000000000, 0xffffffffffffffff );
+  TEST_RR_OP( 14, addw, 0x0000000000000000, 0xffffffffffffffff, 0x0000000000000001 );
+  TEST_RR_OP( 15, addw, 0xfffffffffffffffe, 0xffffffffffffffff, 0xffffffffffffffff );
+
+  TEST_RR_OP( 16, addw, 0xffffffff80000000, 0x0000000000000001, 0x000000007fffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 17, addw, 24, 13, 11 );
+  TEST_RR_SRC2_EQ_DEST( 18, addw, 25, 14, 11 );
+  TEST_RR_SRC12_EQ_DEST( 19, addw, 26, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 20, 0, addw, 24, 13, 11 );
+  TEST_RR_DEST_BYPASS( 21, 1, addw, 25, 14, 11 );
+  TEST_RR_DEST_BYPASS( 22, 2, addw, 26, 15, 11 );
+
+  TEST_RR_SRC12_BYPASS( 23, 0, 0, addw, 24, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 1, addw, 25, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 25, 0, 2, addw, 26, 15, 11 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 0, addw, 24, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 27, 1, 1, addw, 25, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 28, 2, 0, addw, 26, 15, 11 );
+
+  TEST_RR_SRC21_BYPASS( 29, 0, 0, addw, 24, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 1, addw, 25, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 31, 0, 2, addw, 26, 15, 11 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 0, addw, 24, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 33, 1, 1, addw, 25, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 34, 2, 0, addw, 26, 15, 11 );
+
+  TEST_RR_ZEROSRC1( 35, addw, 15, 15 );
+  TEST_RR_ZEROSRC2( 36, addw, 32, 32 );
+  TEST_RR_ZEROSRC12( 37, addw, 0 );
+  TEST_RR_ZERODEST( 38, addw, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-and.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-and.S
@@ -1,0 +1,69 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# and.S
+#-----------------------------------------------------------------------------
+#
+# Test and instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Logical tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, and, 0x0f000f00, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_OP( 3, and, 0x00f000f0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_OP( 4, and, 0x000f000f, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_OP( 5, and, 0xf000f000, 0xf00ff00f, 0xf0f0f0f0 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 6, and, 0x0f000f00, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC2_EQ_DEST( 7, and, 0x00f000f0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC12_EQ_DEST( 8, and, 0xff00ff00, 0xff00ff00 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 9,  0, and, 0x0f000f00, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_DEST_BYPASS( 10, 1, and, 0x00f000f0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_DEST_BYPASS( 11, 2, and, 0x000f000f, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_SRC12_BYPASS( 12, 0, 0, and, 0x0f000f00, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 13, 0, 1, and, 0x00f000f0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC12_BYPASS( 14, 0, 2, and, 0x000f000f, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 15, 1, 0, and, 0x0f000f00, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 16, 1, 1, and, 0x00f000f0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC12_BYPASS( 17, 2, 0, and, 0x000f000f, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_SRC21_BYPASS( 18, 0, 0, and, 0x0f000f00, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 19, 0, 1, and, 0x00f000f0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC21_BYPASS( 20, 0, 2, and, 0x000f000f, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 21, 1, 0, and, 0x0f000f00, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 22, 1, 1, and, 0x00f000f0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC21_BYPASS( 23, 2, 0, and, 0x000f000f, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_ZEROSRC1( 24, and, 0, 0xff00ff00 );
+  TEST_RR_ZEROSRC2( 25, and, 0, 0x00ff00ff );
+  TEST_RR_ZEROSRC12( 26, and, 0 );
+  TEST_RR_ZERODEST( 27, and, 0x11111111, 0x22222222 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-andi.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-andi.S
@@ -1,0 +1,55 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# andi.S
+#-----------------------------------------------------------------------------
+#
+# Test andi instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Logical tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2, andi, 0xff00ff00, 0xff00ff00, 0xf0f );
+  TEST_IMM_OP( 3, andi, 0x000000f0, 0x0ff00ff0, 0x0f0 );
+  TEST_IMM_OP( 4, andi, 0x0000000f, 0x00ff00ff, 0x70f );
+  TEST_IMM_OP( 5, andi, 0x00000000, 0xf00ff00f, 0x0f0 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 6, andi, 0x00000000, 0xff00ff00, 0x0f0 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 7,  0, andi, 0x00000700, 0x0ff00ff0, 0x70f );
+  TEST_IMM_DEST_BYPASS( 8,  1, andi, 0x000000f0, 0x00ff00ff, 0x0f0 );
+  TEST_IMM_DEST_BYPASS( 9,  2, andi, 0xf00ff00f, 0xf00ff00f, 0xf0f );
+
+  TEST_IMM_SRC1_BYPASS( 10, 0, andi, 0x00000700, 0x0ff00ff0, 0x70f );
+  TEST_IMM_SRC1_BYPASS( 11, 1, andi, 0x000000f0, 0x00ff00ff, 0x0f0 );
+  TEST_IMM_SRC1_BYPASS( 12, 2, andi, 0x0000000f, 0xf00ff00f, 0x70f );
+
+  TEST_IMM_ZEROSRC1( 13, andi, 0, 0x0f0 );
+  TEST_IMM_ZERODEST( 14, andi, 0x00ff00ff, 0x70f );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-auipc.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-auipc.S
@@ -1,0 +1,39 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# auipc.S
+#-----------------------------------------------------------------------------
+#
+# Test auipc instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(2, a0, 10000, \
+    .align 3; \
+    lla a0, 1f + 10000; \
+    jal a1, 1f; \
+    1: sub a0, a0, a1; \
+  )
+
+  TEST_CASE(3, a0, -10000, \
+    .align 3; \
+    lla a0, 1f - 10000; \
+    jal a1, 1f; \
+    1: sub a0, a0, a1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-beq.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-beq.S
@@ -1,0 +1,73 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# beq.S
+#-----------------------------------------------------------------------------
+#
+# Test beq instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Branch tests
+  #-------------------------------------------------------------
+
+  # Each test checks both forward and backward branches
+
+  TEST_BR2_OP_TAKEN( 2, beq,  0,  0 );
+  TEST_BR2_OP_TAKEN( 3, beq,  1,  1 );
+  TEST_BR2_OP_TAKEN( 4, beq, -1, -1 );
+
+  TEST_BR2_OP_NOTTAKEN( 5, beq,  0,  1 );
+  TEST_BR2_OP_NOTTAKEN( 6, beq,  1,  0 );
+  TEST_BR2_OP_NOTTAKEN( 7, beq, -1,  1 );
+  TEST_BR2_OP_NOTTAKEN( 8, beq,  1, -1 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_BR2_SRC12_BYPASS( 9,  0, 0, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 10, 0, 1, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 11, 0, 2, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 12, 1, 0, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 13, 1, 1, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 14, 2, 0, beq, 0, -1 );
+
+  TEST_BR2_SRC12_BYPASS( 15, 0, 0, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 16, 0, 1, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 17, 0, 2, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 18, 1, 0, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 19, 1, 1, beq, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 20, 2, 0, beq, 0, -1 );
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  TEST_CASE( 21, x1, 3, \
+    li  x1, 1; \
+    beq x0, x0, 1f; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+1:  addi x1, x1, 1; \
+    addi x1, x1, 1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bge.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bge.S
@@ -1,0 +1,76 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# bge.S
+#-----------------------------------------------------------------------------
+#
+# Test bge instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Branch tests
+  #-------------------------------------------------------------
+
+  # Each test checks both forward and backward branches
+
+  TEST_BR2_OP_TAKEN( 2, bge,  0,  0 );
+  TEST_BR2_OP_TAKEN( 3, bge,  1,  1 );
+  TEST_BR2_OP_TAKEN( 4, bge, -1, -1 );
+  TEST_BR2_OP_TAKEN( 5, bge,  1,  0 );
+  TEST_BR2_OP_TAKEN( 6, bge,  1, -1 );
+  TEST_BR2_OP_TAKEN( 7, bge, -1, -2 );
+
+  TEST_BR2_OP_NOTTAKEN(  8, bge,  0,  1 );
+  TEST_BR2_OP_NOTTAKEN(  9, bge, -1,  1 );
+  TEST_BR2_OP_NOTTAKEN( 10, bge, -2, -1 );
+  TEST_BR2_OP_NOTTAKEN( 11, bge, -2,  1 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_BR2_SRC12_BYPASS( 12, 0, 0, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 13, 0, 1, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 14, 0, 2, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 15, 1, 0, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 16, 1, 1, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 17, 2, 0, bge, -1, 0 );
+
+  TEST_BR2_SRC12_BYPASS( 18, 0, 0, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 19, 0, 1, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 20, 0, 2, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 21, 1, 0, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 22, 1, 1, bge, -1, 0 );
+  TEST_BR2_SRC12_BYPASS( 23, 2, 0, bge, -1, 0 );
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  TEST_CASE( 24, x1, 3, \
+    li  x1, 1; \
+    bge x1, x0, 1f; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+1:  addi x1, x1, 1; \
+    addi x1, x1, 1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bgeu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bgeu.S
@@ -1,0 +1,76 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# bgeu.S
+#-----------------------------------------------------------------------------
+#
+# Test bgeu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Branch tests
+  #-------------------------------------------------------------
+
+  # Each test checks both forward and backward branches
+
+  TEST_BR2_OP_TAKEN( 2, bgeu, 0x00000000, 0x00000000 );
+  TEST_BR2_OP_TAKEN( 3, bgeu, 0x00000001, 0x00000001 );
+  TEST_BR2_OP_TAKEN( 4, bgeu, 0xffffffff, 0xffffffff );
+  TEST_BR2_OP_TAKEN( 5, bgeu, 0x00000001, 0x00000000 );
+  TEST_BR2_OP_TAKEN( 6, bgeu, 0xffffffff, 0xfffffffe );
+  TEST_BR2_OP_TAKEN( 7, bgeu, 0xffffffff, 0x00000000 );
+
+  TEST_BR2_OP_NOTTAKEN(  8, bgeu, 0x00000000, 0x00000001 );
+  TEST_BR2_OP_NOTTAKEN(  9, bgeu, 0xfffffffe, 0xffffffff );
+  TEST_BR2_OP_NOTTAKEN( 10, bgeu, 0x00000000, 0xffffffff );
+  TEST_BR2_OP_NOTTAKEN( 11, bgeu, 0x7fffffff, 0x80000000 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_BR2_SRC12_BYPASS( 12, 0, 0, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 13, 0, 1, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 14, 0, 2, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 15, 1, 0, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 16, 1, 1, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 17, 2, 0, bgeu, 0xefffffff, 0xf0000000 );
+
+  TEST_BR2_SRC12_BYPASS( 18, 0, 0, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 19, 0, 1, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 20, 0, 2, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 21, 1, 0, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 22, 1, 1, bgeu, 0xefffffff, 0xf0000000 );
+  TEST_BR2_SRC12_BYPASS( 23, 2, 0, bgeu, 0xefffffff, 0xf0000000 );
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  TEST_CASE( 24, x1, 3, \
+    li  x1, 1; \
+    bgeu x1, x0, 1f; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+1:  addi x1, x1, 1; \
+    addi x1, x1, 1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-blt.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-blt.S
@@ -1,0 +1,73 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# blt.S
+#-----------------------------------------------------------------------------
+#
+# Test blt instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Branch tests
+  #-------------------------------------------------------------
+
+  # Each test checks both forward and backward branches
+
+  TEST_BR2_OP_TAKEN( 2, blt,  0,  1 );
+  TEST_BR2_OP_TAKEN( 3, blt, -1,  1 );
+  TEST_BR2_OP_TAKEN( 4, blt, -2, -1 );
+
+  TEST_BR2_OP_NOTTAKEN( 5, blt,  1,  0 );
+  TEST_BR2_OP_NOTTAKEN( 6, blt,  1, -1 );
+  TEST_BR2_OP_NOTTAKEN( 7, blt, -1, -2 );
+  TEST_BR2_OP_NOTTAKEN( 8, blt,  1, -2 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_BR2_SRC12_BYPASS( 9,  0, 0, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 10, 0, 1, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 11, 0, 2, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 12, 1, 0, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 13, 1, 1, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 14, 2, 0, blt, 0, -1 );
+
+  TEST_BR2_SRC12_BYPASS( 15, 0, 0, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 16, 0, 1, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 17, 0, 2, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 18, 1, 0, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 19, 1, 1, blt, 0, -1 );
+  TEST_BR2_SRC12_BYPASS( 20, 2, 0, blt, 0, -1 );
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  TEST_CASE( 21, x1, 3, \
+    li  x1, 1; \
+    blt x0, x1, 1f; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+1:  addi x1, x1, 1; \
+    addi x1, x1, 1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bltu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bltu.S
@@ -1,0 +1,73 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# bltu.S
+#-----------------------------------------------------------------------------
+#
+# Test bltu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Branch tests
+  #-------------------------------------------------------------
+
+  # Each test checks both forward and backward branches
+
+  TEST_BR2_OP_TAKEN( 2, bltu, 0x00000000, 0x00000001 );
+  TEST_BR2_OP_TAKEN( 3, bltu, 0xfffffffe, 0xffffffff );
+  TEST_BR2_OP_TAKEN( 4, bltu, 0x00000000, 0xffffffff );
+
+  TEST_BR2_OP_NOTTAKEN( 5, bltu, 0x00000001, 0x00000000 );
+  TEST_BR2_OP_NOTTAKEN( 6, bltu, 0xffffffff, 0xfffffffe );
+  TEST_BR2_OP_NOTTAKEN( 7, bltu, 0xffffffff, 0x00000000 );
+  TEST_BR2_OP_NOTTAKEN( 8, bltu, 0x80000000, 0x7fffffff );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_BR2_SRC12_BYPASS( 9,  0, 0, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 10, 0, 1, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 11, 0, 2, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 12, 1, 0, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 13, 1, 1, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 14, 2, 0, bltu, 0xf0000000, 0xefffffff );
+
+  TEST_BR2_SRC12_BYPASS( 15, 0, 0, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 16, 0, 1, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 17, 0, 2, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 18, 1, 0, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 19, 1, 1, bltu, 0xf0000000, 0xefffffff );
+  TEST_BR2_SRC12_BYPASS( 20, 2, 0, bltu, 0xf0000000, 0xefffffff );
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  TEST_CASE( 21, x1, 3, \
+    li  x1, 1; \
+    bltu x0, x1, 1f; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+1:  addi x1, x1, 1; \
+    addi x1, x1, 1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bne.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-bne.S
@@ -1,0 +1,73 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# bne.S
+#-----------------------------------------------------------------------------
+#
+# Test bne instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Branch tests
+  #-------------------------------------------------------------
+
+  # Each test checks both forward and backward branches
+
+  TEST_BR2_OP_TAKEN( 2, bne,  0,  1 );
+  TEST_BR2_OP_TAKEN( 3, bne,  1,  0 );
+  TEST_BR2_OP_TAKEN( 4, bne, -1,  1 );
+  TEST_BR2_OP_TAKEN( 5, bne,  1, -1 );
+
+  TEST_BR2_OP_NOTTAKEN( 6, bne,  0,  0 );
+  TEST_BR2_OP_NOTTAKEN( 7, bne,  1,  1 );
+  TEST_BR2_OP_NOTTAKEN( 8, bne, -1, -1 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_BR2_SRC12_BYPASS( 9,  0, 0, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 10, 0, 1, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 11, 0, 2, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 12, 1, 0, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 13, 1, 1, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 14, 2, 0, bne, 0, 0 );
+
+  TEST_BR2_SRC12_BYPASS( 15, 0, 0, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 16, 0, 1, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 17, 0, 2, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 18, 1, 0, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 19, 1, 1, bne, 0, 0 );
+  TEST_BR2_SRC12_BYPASS( 20, 2, 0, bne, 0, 0 );
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  TEST_CASE( 21, x1, 3, \
+    li  x1, 1; \
+    bne x1, x0, 1f; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+    addi x1, x1, 1; \
+1:  addi x1, x1, 1; \
+    addi x1, x1, 1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-fence_i.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-fence_i.S
@@ -1,0 +1,54 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# fence_i.S
+#-----------------------------------------------------------------------------
+#
+# Test self-modifying code and the fence.i instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+li a3, 111
+lh a0, insn
+lh a1, insn+2
+
+# test I$ hit
+.align 6
+sh a0, 1f, t0
+sh a1, 1f+2, t0
+fence.i
+
+1: addi a3, a3, 222
+TEST_CASE( 2, a3, 444, nop )
+
+# test prefetcher hit
+li a4, 100
+1: addi a4, a4, -1
+bnez a4, 1b
+
+sh a0, 1f, t0
+sh a1, 1f+2, t0
+fence.i
+
+.align 6
+1: addi a3, a3, 555
+TEST_CASE( 3, a3, 777, nop )
+
+TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+insn:
+  addi a3, a3, 333
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-jal.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-jal.S
@@ -1,0 +1,59 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# jal.S
+#-----------------------------------------------------------------------------
+#
+# Test jal instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Test 2: Basic test
+  #-------------------------------------------------------------
+
+test_2:
+  li  TESTNUM, 2
+  li  ra, 0
+
+  jal x4, target_2
+linkaddr_2:
+  nop
+  nop
+
+  j fail
+
+target_2:
+  la  x2, linkaddr_2
+  bne x2, x4, fail
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  TEST_CASE( 3, ra, 3, \
+    li  ra, 1; \
+    jal x0, 1f; \
+    addi ra, ra, 1; \
+    addi ra, ra, 1; \
+    addi ra, ra, 1; \
+    addi ra, ra, 1; \
+1:  addi ra, ra, 1; \
+    addi ra, ra, 1; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-jalr.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-jalr.S
@@ -1,0 +1,70 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# jalr.S
+#-----------------------------------------------------------------------------
+#
+# Test jalr instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Test 2: Basic test
+  #-------------------------------------------------------------
+
+test_2:
+  li  TESTNUM, 2
+  li  t0, 0
+  la  t1, target_2
+
+  jalr t0, t1, 0
+linkaddr_2:
+  j fail
+
+target_2:
+  la  t1, linkaddr_2
+  bne t0, t1, fail
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_JALR_SRC1_BYPASS( 4, 0, jalr );
+  TEST_JALR_SRC1_BYPASS( 5, 1, jalr );
+  TEST_JALR_SRC1_BYPASS( 6, 2, jalr );
+
+  #-------------------------------------------------------------
+  # Test delay slot instructions not executed nor bypassed
+  #-------------------------------------------------------------
+
+  .option push
+  .align 2
+  .option norvc
+  TEST_CASE( 7, t0, 4, \
+    li  t0, 1; \
+    la  t1, 1f; \
+    jr  t1, -4; \
+    addi t0, t0, 1; \
+    addi t0, t0, 1; \
+    addi t0, t0, 1; \
+    addi t0, t0, 1; \
+1:  addi t0, t0, 1; \
+    addi t0, t0, 1; \
+  )
+  .option pop
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lb.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lb.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lb.S
+#-----------------------------------------------------------------------------
+#
+# Test lb instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lb, 0xffffffffffffffff, 0,  tdat );
+  TEST_LD_OP( 3, lb, 0x0000000000000000, 1,  tdat );
+  TEST_LD_OP( 4, lb, 0xfffffffffffffff0, 2,  tdat );
+  TEST_LD_OP( 5, lb, 0x000000000000000f, 3, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lb, 0xffffffffffffffff, -3, tdat4 );
+  TEST_LD_OP( 7, lb, 0x0000000000000000, -2,  tdat4 );
+  TEST_LD_OP( 8, lb, 0xfffffffffffffff0, -1,  tdat4 );
+  TEST_LD_OP( 9, lb, 0x000000000000000f, 0,   tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0xffffffffffffffff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lb x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x0000000000000000, \
+    la  x1, tdat; \
+    addi x1, x1, -6; \
+    lb x5, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lb, 0xfffffffffffffff0, 1, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lb, 0x000000000000000f, 1, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, lb, 0x0000000000000000, 1, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lb, 0xfffffffffffffff0, 1, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lb, 0x000000000000000f, 1, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lb, 0x0000000000000000, 1, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    lb  x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    lb  x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .byte 0xff
+tdat2:  .byte 0x00
+tdat3:  .byte 0xf0
+tdat4:  .byte 0x0f
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lbu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lbu.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lbu.S
+#-----------------------------------------------------------------------------
+#
+# Test lbu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lbu, 0x00000000000000ff, 0,  tdat );
+  TEST_LD_OP( 3, lbu, 0x0000000000000000, 1,  tdat );
+  TEST_LD_OP( 4, lbu, 0x00000000000000f0, 2,  tdat );
+  TEST_LD_OP( 5, lbu, 0x000000000000000f, 3, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lbu, 0x00000000000000ff, -3, tdat4 );
+  TEST_LD_OP( 7, lbu, 0x0000000000000000, -2,  tdat4 );
+  TEST_LD_OP( 8, lbu, 0x00000000000000f0, -1,  tdat4 );
+  TEST_LD_OP( 9, lbu, 0x000000000000000f, 0,   tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x00000000000000ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lbu x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x0000000000000000, \
+    la  x1, tdat; \
+    addi x1, x1, -6; \
+    lbu x5, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lbu, 0x00000000000000f0, 1, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lbu, 0x000000000000000f, 1, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, lbu, 0x0000000000000000, 1, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lbu, 0x00000000000000f0, 1, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lbu, 0x000000000000000f, 1, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lbu, 0x0000000000000000, 1, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    lbu  x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    lbu  x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .byte 0xff
+tdat2:  .byte 0x00
+tdat3:  .byte 0xf0
+tdat4:  .byte 0x0f
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-ld.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-ld.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# ld.S
+#-----------------------------------------------------------------------------
+#
+# Test ld instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, ld, 0x00ff00ff00ff00ff, 0,  tdat );
+  TEST_LD_OP( 3, ld, 0xff00ff00ff00ff00, 8,  tdat );
+  TEST_LD_OP( 4, ld, 0x0ff00ff00ff00ff0, 16, tdat );
+  TEST_LD_OP( 5, ld, 0xf00ff00ff00ff00f, 24, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, ld, 0x00ff00ff00ff00ff, -24, tdat4 );
+  TEST_LD_OP( 7, ld, 0xff00ff00ff00ff00, -16, tdat4 );
+  TEST_LD_OP( 8, ld, 0x0ff00ff00ff00ff0, -8,  tdat4 );
+  TEST_LD_OP( 9, ld, 0xf00ff00ff00ff00f, 0,   tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x00ff00ff00ff00ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    ld x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0xff00ff00ff00ff00, \
+    la  x1, tdat; \
+    addi x1, x1, -3; \
+    ld x5, 11(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, ld, 0x0ff00ff00ff00ff0, 8, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, ld, 0xf00ff00ff00ff00f, 8, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, ld, 0xff00ff00ff00ff00, 8, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, ld, 0x0ff00ff00ff00ff0, 8, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, ld, 0xf00ff00ff00ff00f, 8, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, ld, 0xff00ff00ff00ff00, 8, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    ld  x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    ld  x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .dword 0x00ff00ff00ff00ff
+tdat2:  .dword 0xff00ff00ff00ff00
+tdat3:  .dword 0x0ff00ff00ff00ff0
+tdat4:  .dword 0xf00ff00ff00ff00f
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lh.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lh.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lh.S
+#-----------------------------------------------------------------------------
+#
+# Test lh instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lh, 0x00000000000000ff, 0,  tdat );
+  TEST_LD_OP( 3, lh, 0xffffffffffffff00, 2,  tdat );
+  TEST_LD_OP( 4, lh, 0x0000000000000ff0, 4,  tdat );
+  TEST_LD_OP( 5, lh, 0xfffffffffffff00f, 6, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lh, 0x00000000000000ff, -6,  tdat4 );
+  TEST_LD_OP( 7, lh, 0xffffffffffffff00, -4,  tdat4 );
+  TEST_LD_OP( 8, lh, 0x0000000000000ff0, -2,  tdat4 );
+  TEST_LD_OP( 9, lh, 0xfffffffffffff00f,  0, tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x00000000000000ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lh x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0xffffffffffffff00, \
+    la  x1, tdat; \
+    addi x1, x1, -5; \
+    lh x5, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lh, 0x0000000000000ff0, 2, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lh, 0xfffffffffffff00f, 2, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, lh, 0xffffffffffffff00, 2, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lh, 0x0000000000000ff0, 2, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lh, 0xfffffffffffff00f, 2, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lh, 0xffffffffffffff00, 2, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    lh  x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    lh  x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .half 0x00ff
+tdat2:  .half 0xff00
+tdat3:  .half 0x0ff0
+tdat4:  .half 0xf00f
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lhu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lhu.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lhu.S
+#-----------------------------------------------------------------------------
+#
+# Test lhu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lhu, 0x00000000000000ff, 0,  tdat );
+  TEST_LD_OP( 3, lhu, 0x000000000000ff00, 2,  tdat );
+  TEST_LD_OP( 4, lhu, 0x0000000000000ff0, 4,  tdat );
+  TEST_LD_OP( 5, lhu, 0x000000000000f00f, 6, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lhu, 0x00000000000000ff, -6,  tdat4 );
+  TEST_LD_OP( 7, lhu, 0x000000000000ff00, -4,  tdat4 );
+  TEST_LD_OP( 8, lhu, 0x0000000000000ff0, -2,  tdat4 );
+  TEST_LD_OP( 9, lhu, 0x000000000000f00f,  0, tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x00000000000000ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lhu x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x000000000000ff00, \
+    la  x1, tdat; \
+    addi x1, x1, -5; \
+    lhu x5, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lhu, 0x0000000000000ff0, 2, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lhu, 0x000000000000f00f, 2, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, lhu, 0x000000000000ff00, 2, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lhu, 0x0000000000000ff0, 2, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lhu, 0x000000000000f00f, 2, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lhu, 0x000000000000ff00, 2, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    lhu  x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    lhu  x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .half 0x00ff
+tdat2:  .half 0xff00
+tdat3:  .half 0x0ff0
+tdat4:  .half 0xf00f
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lui.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lui.S
@@ -1,0 +1,36 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lui.S
+#-----------------------------------------------------------------------------
+#
+# Test lui instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_CASE( 2, x1, 0x0000000000000000, lui x1, 0x00000 );
+  TEST_CASE( 3, x1, 0xfffffffffffff800, lui x1, 0xfffff;sra x1,x1,1);
+  TEST_CASE( 4, x1, 0x00000000000007ff, lui x1, 0x7ffff;sra x1,x1,20);
+  TEST_CASE( 5, x1, 0xfffffffffffff800, lui x1, 0x80000;sra x1,x1,20);
+
+  TEST_CASE( 6, x0, 0, lui x0, 0x80000 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lw.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lw.S
+#-----------------------------------------------------------------------------
+#
+# Test lw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lw, 0x0000000000ff00ff, 0,  tdat );
+  TEST_LD_OP( 3, lw, 0xffffffffff00ff00, 4,  tdat );
+  TEST_LD_OP( 4, lw, 0x000000000ff00ff0, 8,  tdat );
+  TEST_LD_OP( 5, lw, 0xfffffffff00ff00f, 12, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lw, 0x0000000000ff00ff, -12, tdat4 );
+  TEST_LD_OP( 7, lw, 0xffffffffff00ff00, -8,  tdat4 );
+  TEST_LD_OP( 8, lw, 0x000000000ff00ff0, -4,  tdat4 );
+  TEST_LD_OP( 9, lw, 0xfffffffff00ff00f, 0,   tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x0000000000ff00ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lw x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0xffffffffff00ff00, \
+    la  x1, tdat; \
+    addi x1, x1, -3; \
+    lw x5, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lw, 0x000000000ff00ff0, 4, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lw, 0xfffffffff00ff00f, 4, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, lw, 0xffffffffff00ff00, 4, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lw, 0x000000000ff00ff0, 4, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lw, 0xfffffffff00ff00f, 4, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lw, 0xffffffffff00ff00, 4, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    lw  x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    lw  x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .word 0x00ff00ff
+tdat2:  .word 0xff00ff00
+tdat3:  .word 0x0ff00ff0
+tdat4:  .word 0xf00ff00f
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lwu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-lwu.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lwu.S
+#-----------------------------------------------------------------------------
+#
+# Test lwu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lwu, 0x0000000000ff00ff, 0,  tdat );
+  TEST_LD_OP( 3, lwu, 0x00000000ff00ff00, 4,  tdat );
+  TEST_LD_OP( 4, lwu, 0x000000000ff00ff0, 8,  tdat );
+  TEST_LD_OP( 5, lwu, 0x00000000f00ff00f, 12, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lwu, 0x0000000000ff00ff, -12, tdat4 );
+  TEST_LD_OP( 7, lwu, 0x00000000ff00ff00, -8,  tdat4 );
+  TEST_LD_OP( 8, lwu, 0x000000000ff00ff0, -4,  tdat4 );
+  TEST_LD_OP( 9, lwu, 0x00000000f00ff00f, 0,   tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x0000000000ff00ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lwu x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x00000000ff00ff00, \
+    la  x1, tdat; \
+    addi x1, x1, -3; \
+    lwu x5, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lwu, 0x000000000ff00ff0, 4, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lwu, 0x00000000f00ff00f, 4, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, lwu, 0x00000000ff00ff00, 4, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lwu, 0x000000000ff00ff0, 4, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lwu, 0x00000000f00ff00f, 4, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lwu, 0x00000000ff00ff00, 4, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    lwu x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    lwu x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .word 0x00ff00ff
+tdat2:  .word 0xff00ff00
+tdat3:  .word 0x0ff00ff0
+tdat4:  .word 0xf00ff00f
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-or.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-or.S
@@ -1,0 +1,69 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# or.S
+#-----------------------------------------------------------------------------
+#
+# Test or instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Logical tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_OP( 3, or, 0xfff0fff0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_OP( 4, or, 0x0fff0fff, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_OP( 5, or, 0xf0fff0ff, 0xf00ff00f, 0xf0f0f0f0 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 6, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC2_EQ_DEST( 7, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_EQ_DEST( 8, or, 0xff00ff00, 0xff00ff00 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 9,  0, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_DEST_BYPASS( 10, 1, or, 0xfff0fff0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_DEST_BYPASS( 11, 2, or, 0x0fff0fff, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_SRC12_BYPASS( 12, 0, 0, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 13, 0, 1, or, 0xfff0fff0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC12_BYPASS( 14, 0, 2, or, 0x0fff0fff, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 15, 1, 0, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 16, 1, 1, or, 0xfff0fff0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC12_BYPASS( 17, 2, 0, or, 0x0fff0fff, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_SRC21_BYPASS( 18, 0, 0, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 19, 0, 1, or, 0xfff0fff0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC21_BYPASS( 20, 0, 2, or, 0x0fff0fff, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 21, 1, 0, or, 0xff0fff0f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 22, 1, 1, or, 0xfff0fff0, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC21_BYPASS( 23, 2, 0, or, 0x0fff0fff, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_ZEROSRC1( 24, or, 0xff00ff00, 0xff00ff00 );
+  TEST_RR_ZEROSRC2( 25, or, 0x00ff00ff, 0x00ff00ff );
+  TEST_RR_ZEROSRC12( 26, or, 0 );
+  TEST_RR_ZERODEST( 27, or, 0x11111111, 0x22222222 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-ori.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-ori.S
@@ -1,0 +1,55 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# ori.S
+#-----------------------------------------------------------------------------
+#
+# Test ori instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Logical tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2, ori, 0xffffffffffffff0f, 0xffffffffff00ff00, 0xf0f );
+  TEST_IMM_OP( 3, ori, 0x000000000ff00ff0, 0x000000000ff00ff0, 0x0f0 );
+  TEST_IMM_OP( 4, ori, 0x0000000000ff07ff, 0x0000000000ff00ff, 0x70f );
+  TEST_IMM_OP( 5, ori, 0xfffffffff00ff0ff, 0xfffffffff00ff00f, 0x0f0 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 6, ori, 0xff00fff0, 0xff00ff00, 0x0f0 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 7,  0, ori, 0x000000000ff00ff0, 0x000000000ff00ff0, 0x0f0 );
+  TEST_IMM_DEST_BYPASS( 8,  1, ori, 0x0000000000ff07ff, 0x0000000000ff00ff, 0x70f );
+  TEST_IMM_DEST_BYPASS( 9,  2, ori, 0xfffffffff00ff0ff, 0xfffffffff00ff00f, 0x0f0 );
+
+  TEST_IMM_SRC1_BYPASS( 10, 0, ori, 0x000000000ff00ff0, 0x000000000ff00ff0, 0x0f0 );
+  TEST_IMM_SRC1_BYPASS( 11, 1, ori, 0xffffffffffffffff, 0x0000000000ff00ff, 0xf0f );
+  TEST_IMM_SRC1_BYPASS( 12, 2, ori, 0xfffffffff00ff0ff, 0xfffffffff00ff00f, 0x0f0 );
+
+  TEST_IMM_ZEROSRC1( 13, ori, 0x0f0, 0x0f0 );
+  TEST_IMM_ZERODEST( 14, ori, 0x00ff00ff, 0x70f );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sb.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sb.S
@@ -1,0 +1,96 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sb.S
+#-----------------------------------------------------------------------------
+#
+# Test sb instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, lb, sb, 0xffffffffffffffaa, 0, tdat );
+  TEST_ST_OP( 3, lb, sb, 0x0000000000000000, 1, tdat );
+  TEST_ST_OP( 4, lh, sb, 0xffffffffffffefa0, 2, tdat );
+  TEST_ST_OP( 5, lb, sb, 0x000000000000000a, 3, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, lb, sb, 0xffffffffffffffaa, -3, tdat8 );
+  TEST_ST_OP( 7, lb, sb, 0x0000000000000000, -2, tdat8 );
+  TEST_ST_OP( 8, lb, sb, 0xffffffffffffffa0, -1, tdat8 );
+  TEST_ST_OP( 9, lb, sb, 0x000000000000000a, 0,  tdat8 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x78, \
+    la  x1, tdat9; \
+    li  x2, 0x12345678; \
+    addi x4, x1, -32; \
+    sb x2, 32(x4); \
+    lb x5, 0(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0xffffffffffffff98, \
+    la  x1, tdat9; \
+    li  x2, 0x00003098; \
+    addi x1, x1, -6; \
+    sb x2, 7(x1); \
+    la  x4, tdat10; \
+    lb x5, 0(x4); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_ST_SRC12_BYPASS( 12, 0, 0, lb, sb, 0xffffffffffffffdd, 0, tdat );
+  TEST_ST_SRC12_BYPASS( 13, 0, 1, lb, sb, 0xffffffffffffffcd, 1, tdat );
+  TEST_ST_SRC12_BYPASS( 14, 0, 2, lb, sb, 0xffffffffffffffcc, 2, tdat );
+  TEST_ST_SRC12_BYPASS( 15, 1, 0, lb, sb, 0xffffffffffffffbc, 3, tdat );
+  TEST_ST_SRC12_BYPASS( 16, 1, 1, lb, sb, 0xffffffffffffffbb, 4, tdat );
+  TEST_ST_SRC12_BYPASS( 17, 2, 0, lb, sb, 0xffffffffffffffab, 5, tdat );
+
+  TEST_ST_SRC21_BYPASS( 18, 0, 0, lb, sb, 0x33, 0, tdat );
+  TEST_ST_SRC21_BYPASS( 19, 0, 1, lb, sb, 0x23, 1, tdat );
+  TEST_ST_SRC21_BYPASS( 20, 0, 2, lb, sb, 0x22, 2, tdat );
+  TEST_ST_SRC21_BYPASS( 21, 1, 0, lb, sb, 0x12, 3, tdat );
+  TEST_ST_SRC21_BYPASS( 22, 1, 1, lb, sb, 0x11, 4, tdat );
+  TEST_ST_SRC21_BYPASS( 23, 2, 0, lb, sb, 0x01, 5, tdat );
+
+  li a0, 0xef
+  la a1, tdat
+  sb a0, 3(a1)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .byte 0xef
+tdat2:  .byte 0xef
+tdat3:  .byte 0xef
+tdat4:  .byte 0xef
+tdat5:  .byte 0xef
+tdat6:  .byte 0xef
+tdat7:  .byte 0xef
+tdat8:  .byte 0xef
+tdat9:  .byte 0xef
+tdat10: .byte 0xef
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sd.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sd.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sd.S
+#-----------------------------------------------------------------------------
+#
+# Test sd instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, ld, sd, 0x00aa00aa00aa00aa, 0,  tdat );
+  TEST_ST_OP( 3, ld, sd, 0xaa00aa00aa00aa00, 8,  tdat );
+  TEST_ST_OP( 4, ld, sd, 0x0aa00aa00aa00aa0, 16,  tdat );
+  TEST_ST_OP( 5, ld, sd, 0xa00aa00aa00aa00a, 24, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, ld, sd, 0x00aa00aa00aa00aa, -24, tdat8 );
+  TEST_ST_OP( 7, ld, sd, 0xaa00aa00aa00aa00, -16, tdat8 );
+  TEST_ST_OP( 8, ld, sd, 0x0aa00aa00aa00aa0, -8,  tdat8 );
+  TEST_ST_OP( 9, ld, sd, 0xa00aa00aa00aa00a, 0,   tdat8 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x1234567812345678, \
+    la  x1, tdat9; \
+    li  x2, 0x1234567812345678; \
+    addi x4, x1, -32; \
+    sd x2, 32(x4); \
+    ld x5, 0(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x5821309858213098, \
+    la  x1, tdat9; \
+    li  x2, 0x5821309858213098; \
+    addi x1, x1, -3; \
+    sd x2, 11(x1); \
+    la  x4, tdat10; \
+    ld x5, 0(x4); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_ST_SRC12_BYPASS( 12, 0, 0, ld, sd, 0xabbccdd, 0,  tdat );
+  TEST_ST_SRC12_BYPASS( 13, 0, 1, ld, sd, 0xaabbccd, 8,  tdat );
+  TEST_ST_SRC12_BYPASS( 14, 0, 2, ld, sd, 0xdaabbcc, 16, tdat );
+  TEST_ST_SRC12_BYPASS( 15, 1, 0, ld, sd, 0xddaabbc, 24, tdat );
+  TEST_ST_SRC12_BYPASS( 16, 1, 1, ld, sd, 0xcddaabb, 32, tdat );
+  TEST_ST_SRC12_BYPASS( 17, 2, 0, ld, sd, 0xccddaab, 40, tdat );
+
+  TEST_ST_SRC21_BYPASS( 18, 0, 0, ld, sd, 0x00112233, 0,  tdat );
+  TEST_ST_SRC21_BYPASS( 19, 0, 1, ld, sd, 0x30011223, 8,  tdat );
+  TEST_ST_SRC21_BYPASS( 20, 0, 2, ld, sd, 0x33001122, 16, tdat );
+  TEST_ST_SRC21_BYPASS( 21, 1, 0, ld, sd, 0x23300112, 24, tdat );
+  TEST_ST_SRC21_BYPASS( 22, 1, 1, ld, sd, 0x22330011, 32, tdat );
+  TEST_ST_SRC21_BYPASS( 23, 2, 0, ld, sd, 0x12233001, 40, tdat );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .dword 0xdeadbeefdeadbeef
+tdat2:  .dword 0xdeadbeefdeadbeef
+tdat3:  .dword 0xdeadbeefdeadbeef
+tdat4:  .dword 0xdeadbeefdeadbeef
+tdat5:  .dword 0xdeadbeefdeadbeef
+tdat6:  .dword 0xdeadbeefdeadbeef
+tdat7:  .dword 0xdeadbeefdeadbeef
+tdat8:  .dword 0xdeadbeefdeadbeef
+tdat9:  .dword 0xdeadbeefdeadbeef
+tdat10: .dword 0xdeadbeefdeadbeef
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sh.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sh.S
@@ -1,0 +1,96 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sh.S
+#-----------------------------------------------------------------------------
+#
+# Test sh instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, lh, sh, 0x00000000000000aa, 0, tdat );
+  TEST_ST_OP( 3, lh, sh, 0xffffffffffffaa00, 2, tdat );
+  TEST_ST_OP( 4, lw, sh, 0xffffffffbeef0aa0, 4, tdat );
+  TEST_ST_OP( 5, lh, sh, 0xffffffffffffa00a, 6, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, lh, sh, 0x00000000000000aa, -6, tdat8 );
+  TEST_ST_OP( 7, lh, sh, 0xffffffffffffaa00, -4, tdat8 );
+  TEST_ST_OP( 8, lh, sh, 0x0000000000000aa0, -2, tdat8 );
+  TEST_ST_OP( 9, lh, sh, 0xffffffffffffa00a, 0,  tdat8 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x5678, \
+    la  x1, tdat9; \
+    li  x2, 0x12345678; \
+    addi x4, x1, -32; \
+    sh x2, 32(x4); \
+    lh x5, 0(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x3098, \
+    la  x1, tdat9; \
+    li  x2, 0x00003098; \
+    addi x1, x1, -5; \
+    sh x2, 7(x1); \
+    la  x4, tdat10; \
+    lh x5, 0(x4); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_ST_SRC12_BYPASS( 12, 0, 0, lh, sh, 0xffffffffffffccdd, 0,  tdat );
+  TEST_ST_SRC12_BYPASS( 13, 0, 1, lh, sh, 0xffffffffffffbccd, 2,  tdat );
+  TEST_ST_SRC12_BYPASS( 14, 0, 2, lh, sh, 0xffffffffffffbbcc, 4,  tdat );
+  TEST_ST_SRC12_BYPASS( 15, 1, 0, lh, sh, 0xffffffffffffabbc, 6, tdat );
+  TEST_ST_SRC12_BYPASS( 16, 1, 1, lh, sh, 0xffffffffffffaabb, 8, tdat );
+  TEST_ST_SRC12_BYPASS( 17, 2, 0, lh, sh, 0xffffffffffffdaab, 10, tdat );
+
+  TEST_ST_SRC21_BYPASS( 18, 0, 0, lh, sh, 0x2233, 0,  tdat );
+  TEST_ST_SRC21_BYPASS( 19, 0, 1, lh, sh, 0x1223, 2,  tdat );
+  TEST_ST_SRC21_BYPASS( 20, 0, 2, lh, sh, 0x1122, 4,  tdat );
+  TEST_ST_SRC21_BYPASS( 21, 1, 0, lh, sh, 0x0112, 6, tdat );
+  TEST_ST_SRC21_BYPASS( 22, 1, 1, lh, sh, 0x0011, 8, tdat );
+  TEST_ST_SRC21_BYPASS( 23, 2, 0, lh, sh, 0x3001, 10, tdat );
+
+  li a0, 0xbeef
+  la a1, tdat
+  sh a0, 6(a1)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .half 0xbeef
+tdat2:  .half 0xbeef
+tdat3:  .half 0xbeef
+tdat4:  .half 0xbeef
+tdat5:  .half 0xbeef
+tdat6:  .half 0xbeef
+tdat7:  .half 0xbeef
+tdat8:  .half 0xbeef
+tdat9:  .half 0xbeef
+tdat10: .half 0xbeef
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-short-addi.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-short-addi.S
@@ -1,0 +1,71 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# addi.S
+#-----------------------------------------------------------------------------
+#
+# Test addi instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  addi, 0x00000000, 0x00000000, 0x000 );
+#  TEST_IMM_OP( 3,  addi, 0x00000002, 0x00000001, 0x001 );
+#  TEST_IMM_OP( 4,  addi, 0x0000000a, 0x00000003, 0x007 );
+#
+#  TEST_IMM_OP( 5,  addi, 0xfffffffffffff800, 0x0000000000000000, 0x800 );
+#  TEST_IMM_OP( 6,  addi, 0xffffffff80000000, 0xffffffff80000000, 0x000 );
+#  TEST_IMM_OP( 7,  addi, 0xffffffff7ffff800, 0xffffffff80000000, 0x800 );
+#
+#  TEST_IMM_OP( 8,  addi, 0x00000000000007ff, 0x00000000, 0x7ff );
+#  TEST_IMM_OP( 9,  addi, 0x000000007fffffff, 0x7fffffff, 0x000 );
+#  TEST_IMM_OP( 10, addi, 0x00000000800007fe, 0x7fffffff, 0x7ff );
+#
+#  TEST_IMM_OP( 11, addi, 0xffffffff800007ff, 0xffffffff80000000, 0x7ff );
+#  TEST_IMM_OP( 12, addi, 0x000000007ffff7ff, 0x000000007fffffff, 0x800 );
+#
+#  TEST_IMM_OP( 13, addi, 0xffffffffffffffff, 0x0000000000000000, 0xfff );
+#  TEST_IMM_OP( 14, addi, 0x0000000000000000, 0xffffffffffffffff, 0x001 );
+#  TEST_IMM_OP( 15, addi, 0xfffffffffffffffe, 0xffffffffffffffff, 0xfff );
+#
+#  TEST_IMM_OP( 16, addi, 0x0000000080000000, 0x7fffffff, 0x001 );
+#
+#  #-------------------------------------------------------------
+#  # Source/Destination tests
+#  #-------------------------------------------------------------
+#
+#  TEST_IMM_SRC1_EQ_DEST( 17, addi, 24, 13, 11 );
+#
+#  #-------------------------------------------------------------
+#  # Bypassing tests
+#  #-------------------------------------------------------------
+#
+#  TEST_IMM_DEST_BYPASS( 18, 0, addi, 24, 13, 11 );
+#  TEST_IMM_DEST_BYPASS( 19, 1, addi, 23, 13, 10 );
+#  TEST_IMM_DEST_BYPASS( 20, 2, addi, 22, 13,  9 );
+#
+#  TEST_IMM_SRC1_BYPASS( 21, 0, addi, 24, 13, 11 );
+#  TEST_IMM_SRC1_BYPASS( 22, 1, addi, 23, 13, 10 );
+#  TEST_IMM_SRC1_BYPASS( 23, 2, addi, 22, 13,  9 );
+#
+#  TEST_IMM_ZEROSRC1( 24, addi, 32, 32 );
+#  TEST_IMM_ZERODEST( 25, addi, 33, 50 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-short-sd.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-short-sd.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sd.S
+#-----------------------------------------------------------------------------
+#
+# Test sd instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, ld, sd, 0x00aa00aa00aa00aa, 0,  tdat );
+  TEST_ST_OP( 3, ld, sd, 0xaa00aa00aa00aa00, 8,  tdat );
+  TEST_ST_OP( 4, ld, sd, 0x0aa00aa00aa00aa0, 16,  tdat );
+  TEST_ST_OP( 5, ld, sd, 0xa00aa00aa00aa00a, 24, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, ld, sd, 0x00aa00aa00aa00aa, -24, tdat8 );
+  TEST_ST_OP( 7, ld, sd, 0xaa00aa00aa00aa00, -16, tdat8 );
+  TEST_ST_OP( 8, ld, sd, 0x0aa00aa00aa00aa0, -8,  tdat8 );
+  TEST_ST_OP( 9, ld, sd, 0xa00aa00aa00aa00a, 0,   tdat8 );
+
+#  # Test with a negative base
+#
+#  TEST_CASE( 10, x5, 0x1234567812345678, \
+#    la  x1, tdat9; \
+#    li  x2, 0x1234567812345678; \
+#    addi x4, x1, -32; \
+#    sd x2, 32(x4); \
+#    ld x5, 0(x1); \
+#  )
+#
+#  # Test with unaligned base
+#
+#  TEST_CASE( 11, x5, 0x5821309858213098, \
+#    la  x1, tdat9; \
+#    li  x2, 0x5821309858213098; \
+#    addi x1, x1, -3; \
+#    sd x2, 11(x1); \
+#    la  x4, tdat10; \
+#    ld x5, 0(x4); \
+#  )
+#
+#  #-------------------------------------------------------------
+#  # Bypassing tests
+#  #-------------------------------------------------------------
+#
+#  TEST_ST_SRC12_BYPASS( 12, 0, 0, ld, sd, 0xabbccdd, 0,  tdat );
+#  TEST_ST_SRC12_BYPASS( 13, 0, 1, ld, sd, 0xaabbccd, 8,  tdat );
+#  TEST_ST_SRC12_BYPASS( 14, 0, 2, ld, sd, 0xdaabbcc, 16, tdat );
+#  TEST_ST_SRC12_BYPASS( 15, 1, 0, ld, sd, 0xddaabbc, 24, tdat );
+#  TEST_ST_SRC12_BYPASS( 16, 1, 1, ld, sd, 0xcddaabb, 32, tdat );
+#  TEST_ST_SRC12_BYPASS( 17, 2, 0, ld, sd, 0xccddaab, 40, tdat );
+#
+#  TEST_ST_SRC21_BYPASS( 18, 0, 0, ld, sd, 0x00112233, 0,  tdat );
+#  TEST_ST_SRC21_BYPASS( 19, 0, 1, ld, sd, 0x30011223, 8,  tdat );
+#  TEST_ST_SRC21_BYPASS( 20, 0, 2, ld, sd, 0x33001122, 16, tdat );
+#  TEST_ST_SRC21_BYPASS( 21, 1, 0, ld, sd, 0x23300112, 24, tdat );
+#  TEST_ST_SRC21_BYPASS( 22, 1, 1, ld, sd, 0x22330011, 32, tdat );
+#  TEST_ST_SRC21_BYPASS( 23, 2, 0, ld, sd, 0x12233001, 40, tdat );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .dword 0xdeadbeefdeadbeef
+tdat2:  .dword 0xdeadbeefdeadbeef
+tdat3:  .dword 0xdeadbeefdeadbeef
+tdat4:  .dword 0xdeadbeefdeadbeef
+tdat5:  .dword 0xdeadbeefdeadbeef
+tdat6:  .dword 0xdeadbeefdeadbeef
+tdat7:  .dword 0xdeadbeefdeadbeef
+tdat8:  .dword 0xdeadbeefdeadbeef
+tdat9:  .dword 0xdeadbeefdeadbeef
+tdat10: .dword 0xdeadbeefdeadbeef
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-simple.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-simple.S
@@ -1,0 +1,27 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# simple.S
+#-----------------------------------------------------------------------------
+#
+# This is the most basic self checking test. If your simulator does not
+# pass thiss then there is little chance that it will pass any of the
+# more complicated self checking tests.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+RVTEST_PASS
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sll.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sll.S
@@ -1,0 +1,96 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sll.S
+#-----------------------------------------------------------------------------
+#
+# Test sll instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  sll, 0x0000000000000001, 0x0000000000000001, 0  );
+  TEST_RR_OP( 3,  sll, 0x0000000000000002, 0x0000000000000001, 1  );
+  TEST_RR_OP( 4,  sll, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_OP( 5,  sll, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_OP( 6,  sll, 0x0000000080000000, 0x0000000000000001, 31 );
+
+  TEST_RR_OP( 7,  sll, 0xffffffffffffffff, 0xffffffffffffffff, 0  );
+  TEST_RR_OP( 8,  sll, 0xfffffffffffffffe, 0xffffffffffffffff, 1  );
+  TEST_RR_OP( 9,  sll, 0xffffffffffffff80, 0xffffffffffffffff, 7  );
+  TEST_RR_OP( 10, sll, 0xffffffffffffc000, 0xffffffffffffffff, 14 );
+  TEST_RR_OP( 11, sll, 0xffffffff80000000, 0xffffffffffffffff, 31 );
+
+  TEST_RR_OP( 12, sll, 0x0000000021212121, 0x0000000021212121, 0  );
+  TEST_RR_OP( 13, sll, 0x0000000042424242, 0x0000000021212121, 1  );
+  TEST_RR_OP( 14, sll, 0x0000001090909080, 0x0000000021212121, 7  );
+  TEST_RR_OP( 15, sll, 0x0000084848484000, 0x0000000021212121, 14 );
+  TEST_RR_OP( 16, sll, 0x1090909080000000, 0x0000000021212121, 31 );
+
+  # Verify that shifts only use bottom six bits
+
+  TEST_RR_OP( 17, sll, 0x0000000021212121, 0x0000000021212121, 0xffffffffffffffc0 );
+  TEST_RR_OP( 18, sll, 0x0000000042424242, 0x0000000021212121, 0xffffffffffffffc1 );
+  TEST_RR_OP( 19, sll, 0x0000001090909080, 0x0000000021212121, 0xffffffffffffffc7 );
+  TEST_RR_OP( 20, sll, 0x0000084848484000, 0x0000000021212121, 0xffffffffffffffce );
+
+#if __riscv_xlen == 64
+  TEST_RR_OP( 21, sll, 0x8000000000000000, 0x0000000021212121, 0xffffffffffffffff );
+  TEST_RR_OP( 50, sll, 0x8000000000000000, 0x0000000000000001, 63 );
+  TEST_RR_OP( 51, sll, 0xffffff8000000000, 0xffffffffffffffff, 39 );
+  TEST_RR_OP( 52, sll, 0x0909080000000000, 0x0000000021212121, 43 );
+#endif
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 22, sll, 0x00000080, 0x00000001, 7  );
+  TEST_RR_SRC2_EQ_DEST( 23, sll, 0x00004000, 0x00000001, 14 );
+  TEST_RR_SRC12_EQ_DEST( 24, sll, 24, 3 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 25, 0, sll, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_DEST_BYPASS( 26, 1, sll, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_DEST_BYPASS( 27, 2, sll, 0x0000000080000000, 0x0000000000000001, 31 );
+
+  TEST_RR_SRC12_BYPASS( 28, 0, 0, sll, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC12_BYPASS( 29, 0, 1, sll, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC12_BYPASS( 30, 0, 2, sll, 0x0000000080000000, 0x0000000000000001, 31 );
+  TEST_RR_SRC12_BYPASS( 31, 1, 0, sll, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC12_BYPASS( 32, 1, 1, sll, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC12_BYPASS( 33, 2, 0, sll, 0x0000000080000000, 0x0000000000000001, 31 );
+
+  TEST_RR_SRC21_BYPASS( 34, 0, 0, sll, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC21_BYPASS( 35, 0, 1, sll, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC21_BYPASS( 36, 0, 2, sll, 0x0000000080000000, 0x0000000000000001, 31 );
+  TEST_RR_SRC21_BYPASS( 37, 1, 0, sll, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC21_BYPASS( 38, 1, 1, sll, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC21_BYPASS( 39, 2, 0, sll, 0x0000000080000000, 0x0000000000000001, 31 );
+
+  TEST_RR_ZEROSRC1( 40, sll, 0, 15 );
+  TEST_RR_ZEROSRC2( 41, sll, 32, 32 );
+  TEST_RR_ZEROSRC12( 42, sll, 0 );
+  TEST_RR_ZERODEST( 43, sll, 1024, 2048 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slli.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slli.S
@@ -1,0 +1,74 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# slli.S
+#-----------------------------------------------------------------------------
+#
+# Test slli instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  slli, 0x0000000000000001, 0x0000000000000001, 0  );
+  TEST_IMM_OP( 3,  slli, 0x0000000000000002, 0x0000000000000001, 1  );
+  TEST_IMM_OP( 4,  slli, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_IMM_OP( 5,  slli, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_IMM_OP( 6,  slli, 0x0000000080000000, 0x0000000000000001, 31 );
+
+  TEST_IMM_OP( 7,  slli, 0xffffffffffffffff, 0xffffffffffffffff, 0  );
+  TEST_IMM_OP( 8,  slli, 0xfffffffffffffffe, 0xffffffffffffffff, 1  );
+  TEST_IMM_OP( 9,  slli, 0xffffffffffffff80, 0xffffffffffffffff, 7  );
+  TEST_IMM_OP( 10, slli, 0xffffffffffffc000, 0xffffffffffffffff, 14 );
+  TEST_IMM_OP( 11, slli, 0xffffffff80000000, 0xffffffffffffffff, 31 );
+
+  TEST_IMM_OP( 12, slli, 0x0000000021212121, 0x0000000021212121, 0  );
+  TEST_IMM_OP( 13, slli, 0x0000000042424242, 0x0000000021212121, 1  );
+  TEST_IMM_OP( 14, slli, 0x0000001090909080, 0x0000000021212121, 7  );
+  TEST_IMM_OP( 15, slli, 0x0000084848484000, 0x0000000021212121, 14 );
+  TEST_IMM_OP( 16, slli, 0x1090909080000000, 0x0000000021212121, 31 );
+
+#if __riscv_xlen == 64
+  TEST_IMM_OP( 50, slli, 0x8000000000000000, 0x0000000000000001, 63 );
+  TEST_IMM_OP( 51, slli, 0xffffff8000000000, 0xffffffffffffffff, 39 );
+  TEST_IMM_OP( 52, slli, 0x0909080000000000, 0x0000000021212121, 43 );
+#endif
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, slli, 0x00000080, 0x00000001, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, slli, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, slli, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, slli, 0x0000000080000000, 0x0000000000000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, slli, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_IMM_SRC1_BYPASS( 22, 1, slli, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, slli, 0x0000000080000000, 0x0000000000000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, slli, 0, 31 );
+  TEST_IMM_ZERODEST( 25, slli, 33, 20 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slliw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slliw.S
@@ -1,0 +1,68 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# slliw.S
+#-----------------------------------------------------------------------------
+#
+# Test slliw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  slliw, 0x0000000000000001, 0x0000000000000001, 0  );
+  TEST_IMM_OP( 3,  slliw, 0x0000000000000002, 0x0000000000000001, 1  );
+  TEST_IMM_OP( 4,  slliw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_IMM_OP( 5,  slliw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_IMM_OP( 6,  slliw, 0xffffffff80000000, 0x0000000000000001, 31 );
+
+  TEST_IMM_OP( 7,  slliw, 0xffffffffffffffff, 0xffffffffffffffff, 0  );
+  TEST_IMM_OP( 8,  slliw, 0xfffffffffffffffe, 0xffffffffffffffff, 1  );
+  TEST_IMM_OP( 9,  slliw, 0xffffffffffffff80, 0xffffffffffffffff, 7  );
+  TEST_IMM_OP( 10, slliw, 0xffffffffffffc000, 0xffffffffffffffff, 14 );
+  TEST_IMM_OP( 11, slliw, 0xffffffff80000000, 0xffffffffffffffff, 31 );
+
+  TEST_IMM_OP( 12, slliw, 0x0000000021212121, 0x0000000021212121, 0  );
+  TEST_IMM_OP( 13, slliw, 0x0000000042424242, 0x0000000021212121, 1  );
+  TEST_IMM_OP( 14, slliw, 0xffffffff90909080, 0x0000000021212121, 7  );
+  TEST_IMM_OP( 15, slliw, 0x0000000048484000, 0x0000000021212121, 14 );
+  TEST_IMM_OP( 16, slliw, 0xffffffff80000000, 0x0000000021212121, 31 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, slliw, 0x00000080, 0x00000001, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, slliw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, slliw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, slliw, 0xffffffff80000000, 0x0000000000000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, slliw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_IMM_SRC1_BYPASS( 22, 1, slliw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, slliw, 0xffffffff80000000, 0x0000000000000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, slliw, 0, 31 );
+  TEST_IMM_ZERODEST( 25, slliw, 31, 28 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sllw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sllw.S
@@ -1,0 +1,90 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sllw.S
+#-----------------------------------------------------------------------------
+#
+# Test sllw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  sllw, 0x0000000000000001, 0x0000000000000001, 0  );
+  TEST_RR_OP( 3,  sllw, 0x0000000000000002, 0x0000000000000001, 1  );
+  TEST_RR_OP( 4,  sllw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_OP( 5,  sllw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_OP( 6,  sllw, 0xffffffff80000000, 0x0000000000000001, 31 );
+
+  TEST_RR_OP( 7,  sllw, 0xffffffffffffffff, 0xffffffffffffffff, 0  );
+  TEST_RR_OP( 8,  sllw, 0xfffffffffffffffe, 0xffffffffffffffff, 1  );
+  TEST_RR_OP( 9,  sllw, 0xffffffffffffff80, 0xffffffffffffffff, 7  );
+  TEST_RR_OP( 10, sllw, 0xffffffffffffc000, 0xffffffffffffffff, 14 );
+  TEST_RR_OP( 11, sllw, 0xffffffff80000000, 0xffffffffffffffff, 31 );
+
+  TEST_RR_OP( 12, sllw, 0x0000000021212121, 0x0000000021212121, 0  );
+  TEST_RR_OP( 13, sllw, 0x0000000042424242, 0x0000000021212121, 1  );
+  TEST_RR_OP( 14, sllw, 0xffffffff90909080, 0x0000000021212121, 7  );
+  TEST_RR_OP( 15, sllw, 0x0000000048484000, 0x0000000021212121, 14 );
+  TEST_RR_OP( 16, sllw, 0xffffffff80000000, 0x0000000021212121, 31 );
+
+  # Verify that shifts only use bottom five bits
+
+  TEST_RR_OP( 17, sllw, 0x0000000021212121, 0x0000000021212121, 0xffffffffffffffe0 );
+  TEST_RR_OP( 18, sllw, 0x0000000042424242, 0x0000000021212121, 0xffffffffffffffe1 );
+  TEST_RR_OP( 19, sllw, 0xffffffff90909080, 0x0000000021212121, 0xffffffffffffffe7 );
+  TEST_RR_OP( 20, sllw, 0x0000000048484000, 0x0000000021212121, 0xffffffffffffffee );
+  TEST_RR_OP( 21, sllw, 0xffffffff80000000, 0x0000000021212121, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 22, sllw, 0x00000080, 0x00000001, 7  );
+  TEST_RR_SRC2_EQ_DEST( 23, sllw, 0x00004000, 0x00000001, 14 );
+  TEST_RR_SRC12_EQ_DEST( 24, sllw, 24, 3 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 25, 0, sllw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_DEST_BYPASS( 26, 1, sllw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_DEST_BYPASS( 27, 2, sllw, 0xffffffff80000000, 0x0000000000000001, 31 );
+
+  TEST_RR_SRC12_BYPASS( 28, 0, 0, sllw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC12_BYPASS( 29, 0, 1, sllw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC12_BYPASS( 30, 0, 2, sllw, 0xffffffff80000000, 0x0000000000000001, 31 );
+  TEST_RR_SRC12_BYPASS( 31, 1, 0, sllw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC12_BYPASS( 32, 1, 1, sllw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC12_BYPASS( 33, 2, 0, sllw, 0xffffffff80000000, 0x0000000000000001, 31 );
+
+  TEST_RR_SRC21_BYPASS( 34, 0, 0, sllw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC21_BYPASS( 35, 0, 1, sllw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC21_BYPASS( 36, 0, 2, sllw, 0xffffffff80000000, 0x0000000000000001, 31 );
+  TEST_RR_SRC21_BYPASS( 37, 1, 0, sllw, 0x0000000000000080, 0x0000000000000001, 7  );
+  TEST_RR_SRC21_BYPASS( 38, 1, 1, sllw, 0x0000000000004000, 0x0000000000000001, 14 );
+  TEST_RR_SRC21_BYPASS( 39, 2, 0, sllw, 0xffffffff80000000, 0x0000000000000001, 31 );
+
+  TEST_RR_ZEROSRC1( 40, sllw, 0, 15 );
+  TEST_RR_ZEROSRC2( 41, sllw, 32, 32 );
+  TEST_RR_ZEROSRC12( 42, sllw, 0 );
+  TEST_RR_ZERODEST( 43, sllw, 1024, 2048 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slt.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slt.S
@@ -1,0 +1,84 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# slt.S
+#-----------------------------------------------------------------------------
+#
+# Test slt instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  slt, 0, 0x0000000000000000, 0x0000000000000000 );
+  TEST_RR_OP( 3,  slt, 0, 0x0000000000000001, 0x0000000000000001 );
+  TEST_RR_OP( 4,  slt, 1, 0x0000000000000003, 0x0000000000000007 );
+  TEST_RR_OP( 5,  slt, 0, 0x0000000000000007, 0x0000000000000003 );
+
+  TEST_RR_OP( 6,  slt, 0, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 7,  slt, 1, 0xffffffff80000000, 0x0000000000000000 );
+  TEST_RR_OP( 8,  slt, 1, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 9,  slt, 1, 0x0000000000000000, 0x0000000000007fff );
+  TEST_RR_OP( 10, slt, 0, 0x000000007fffffff, 0x0000000000000000 );
+  TEST_RR_OP( 11, slt, 0, 0x000000007fffffff, 0x0000000000007fff );
+
+  TEST_RR_OP( 12, slt, 1, 0xffffffff80000000, 0x0000000000007fff );
+  TEST_RR_OP( 13, slt, 0, 0x000000007fffffff, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 14, slt, 0, 0x0000000000000000, 0xffffffffffffffff );
+  TEST_RR_OP( 15, slt, 1, 0xffffffffffffffff, 0x0000000000000001 );
+  TEST_RR_OP( 16, slt, 0, 0xffffffffffffffff, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 17, slt, 0, 14, 13 );
+  TEST_RR_SRC2_EQ_DEST( 18, slt, 1, 11, 13 );
+  TEST_RR_SRC12_EQ_DEST( 19, slt, 0, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 20, 0, slt, 1, 11, 13 );
+  TEST_RR_DEST_BYPASS( 21, 1, slt, 0, 14, 13 );
+  TEST_RR_DEST_BYPASS( 22, 2, slt, 1, 12, 13 );
+
+  TEST_RR_SRC12_BYPASS( 23, 0, 0, slt, 0, 14, 13 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 1, slt, 1, 11, 13 );
+  TEST_RR_SRC12_BYPASS( 25, 0, 2, slt, 0, 15, 13 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 0, slt, 1, 10, 13 );
+  TEST_RR_SRC12_BYPASS( 27, 1, 1, slt, 0, 16, 13 );
+  TEST_RR_SRC12_BYPASS( 28, 2, 0, slt, 1,  9, 13 );
+
+  TEST_RR_SRC21_BYPASS( 29, 0, 0, slt, 0, 17, 13 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 1, slt, 1,  8, 13 );
+  TEST_RR_SRC21_BYPASS( 31, 0, 2, slt, 0, 18, 13 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 0, slt, 1,  7, 13 );
+  TEST_RR_SRC21_BYPASS( 33, 1, 1, slt, 0, 19, 13 );
+  TEST_RR_SRC21_BYPASS( 34, 2, 0, slt, 1,  6, 13 );
+
+  TEST_RR_ZEROSRC1( 35, slt, 0, -1 );
+  TEST_RR_ZEROSRC2( 36, slt, 1, -1 );
+  TEST_RR_ZEROSRC12( 37, slt, 0 );
+  TEST_RR_ZERODEST( 38, slt, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slti.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-slti.S
@@ -1,0 +1,70 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# slti.S
+#-----------------------------------------------------------------------------
+#
+# Test slti instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  slti, 0, 0x0000000000000000, 0x000 );
+  TEST_IMM_OP( 3,  slti, 0, 0x0000000000000001, 0x001 );
+  TEST_IMM_OP( 4,  slti, 1, 0x0000000000000003, 0x007 );
+  TEST_IMM_OP( 5,  slti, 0, 0x0000000000000007, 0x003 );
+
+  TEST_IMM_OP( 6,  slti, 0, 0x0000000000000000, 0x800 );
+  TEST_IMM_OP( 7,  slti, 1, 0xffffffff80000000, 0x000 );
+  TEST_IMM_OP( 8,  slti, 1, 0xffffffff80000000, 0x800 );
+
+  TEST_IMM_OP( 9,  slti, 1, 0x0000000000000000, 0x7ff );
+  TEST_IMM_OP( 10, slti, 0, 0x000000007fffffff, 0x000 );
+  TEST_IMM_OP( 11, slti, 0, 0x000000007fffffff, 0x7ff );
+
+  TEST_IMM_OP( 12, slti, 1, 0xffffffff80000000, 0x7ff );
+  TEST_IMM_OP( 13, slti, 0, 0x000000007fffffff, 0x800 );
+
+  TEST_IMM_OP( 14, slti, 0, 0x0000000000000000, 0xfff );
+  TEST_IMM_OP( 15, slti, 1, 0xffffffffffffffff, 0x001 );
+  TEST_IMM_OP( 16, slti, 0, 0xffffffffffffffff, 0xfff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, slti, 1, 11, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, slti, 0, 15, 10 );
+  TEST_IMM_DEST_BYPASS( 19, 1, slti, 1, 10, 16 );
+  TEST_IMM_DEST_BYPASS( 20, 2, slti, 0, 16,  9 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, slti, 1, 11, 15 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, slti, 0, 17,  8 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, slti, 1, 12, 14 );
+
+  TEST_IMM_ZEROSRC1( 24, slti, 0, 0xfff );
+  TEST_IMM_ZERODEST( 25, slti, 0x00ff00ff, 0xfff );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sltiu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sltiu.S
@@ -1,0 +1,70 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sltiu.S
+#-----------------------------------------------------------------------------
+#
+# Test sltiu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  sltiu, 0, 0x0000000000000000, 0x000 );
+  TEST_IMM_OP( 3,  sltiu, 0, 0x0000000000000001, 0x001 );
+  TEST_IMM_OP( 4,  sltiu, 1, 0x0000000000000003, 0x007 );
+  TEST_IMM_OP( 5,  sltiu, 0, 0x0000000000000007, 0x003 );
+
+  TEST_IMM_OP( 6,  sltiu, 1, 0x0000000000000000, 0x800 );
+  TEST_IMM_OP( 7,  sltiu, 0, 0xffffffff80000000, 0x000 );
+  TEST_IMM_OP( 8,  sltiu, 1, 0xffffffff80000000, 0x800 );
+
+  TEST_IMM_OP( 9,  sltiu, 1, 0x0000000000000000, 0x7ff );
+  TEST_IMM_OP( 10, sltiu, 0, 0x000000007fffffff, 0x000 );
+  TEST_IMM_OP( 11, sltiu, 0, 0x000000007fffffff, 0x7ff );
+
+  TEST_IMM_OP( 12, sltiu, 0, 0xffffffff80000000, 0x7ff );
+  TEST_IMM_OP( 13, sltiu, 1, 0x000000007fffffff, 0x800 );
+
+  TEST_IMM_OP( 14, sltiu, 1, 0x0000000000000000, 0xfff );
+  TEST_IMM_OP( 15, sltiu, 0, 0xffffffffffffffff, 0x001 );
+  TEST_IMM_OP( 16, sltiu, 0, 0xffffffffffffffff, 0xfff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, sltiu, 1, 11, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, sltiu, 0, 15, 10 );
+  TEST_IMM_DEST_BYPASS( 19, 1, sltiu, 1, 10, 16 );
+  TEST_IMM_DEST_BYPASS( 20, 2, sltiu, 0, 16,  9 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, sltiu, 1, 11, 15 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, sltiu, 0, 17,  8 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, sltiu, 1, 12, 14 );
+
+  TEST_IMM_ZEROSRC1( 24, sltiu, 1, 0xfff );
+  TEST_IMM_ZERODEST( 25, sltiu, 0x00ff00ff, 0xfff );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sltu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sltu.S
@@ -1,0 +1,84 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sltu.S
+#-----------------------------------------------------------------------------
+#
+# Test sltu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  sltu, 0, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  sltu, 0, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  sltu, 1, 0x00000003, 0x00000007 );
+  TEST_RR_OP( 5,  sltu, 0, 0x00000007, 0x00000003 );
+
+  TEST_RR_OP( 6,  sltu, 1, 0x00000000, 0xffff8000 );
+  TEST_RR_OP( 7,  sltu, 0, 0x80000000, 0x00000000 );
+  TEST_RR_OP( 8,  sltu, 1, 0x80000000, 0xffff8000 );
+
+  TEST_RR_OP( 9,  sltu, 1, 0x00000000, 0x00007fff );
+  TEST_RR_OP( 10, sltu, 0, 0x7fffffff, 0x00000000 );
+  TEST_RR_OP( 11, sltu, 0, 0x7fffffff, 0x00007fff );
+
+  TEST_RR_OP( 12, sltu, 0, 0x80000000, 0x00007fff );
+  TEST_RR_OP( 13, sltu, 1, 0x7fffffff, 0xffff8000 );
+
+  TEST_RR_OP( 14, sltu, 1, 0x00000000, 0xffffffff );
+  TEST_RR_OP( 15, sltu, 0, 0xffffffff, 0x00000001 );
+  TEST_RR_OP( 16, sltu, 0, 0xffffffff, 0xffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 17, sltu, 0, 14, 13 );
+  TEST_RR_SRC2_EQ_DEST( 18, sltu, 1, 11, 13 );
+  TEST_RR_SRC12_EQ_DEST( 19, sltu, 0, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 20, 0, sltu, 1, 11, 13 );
+  TEST_RR_DEST_BYPASS( 21, 1, sltu, 0, 14, 13 );
+  TEST_RR_DEST_BYPASS( 22, 2, sltu, 1, 12, 13 );
+
+  TEST_RR_SRC12_BYPASS( 23, 0, 0, sltu, 0, 14, 13 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 1, sltu, 1, 11, 13 );
+  TEST_RR_SRC12_BYPASS( 25, 0, 2, sltu, 0, 15, 13 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 0, sltu, 1, 10, 13 );
+  TEST_RR_SRC12_BYPASS( 27, 1, 1, sltu, 0, 16, 13 );
+  TEST_RR_SRC12_BYPASS( 28, 2, 0, sltu, 1,  9, 13 );
+
+  TEST_RR_SRC21_BYPASS( 29, 0, 0, sltu, 0, 17, 13 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 1, sltu, 1,  8, 13 );
+  TEST_RR_SRC21_BYPASS( 31, 0, 2, sltu, 0, 18, 13 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 0, sltu, 1,  7, 13 );
+  TEST_RR_SRC21_BYPASS( 33, 1, 1, sltu, 0, 19, 13 );
+  TEST_RR_SRC21_BYPASS( 34, 2, 0, sltu, 1,  6, 13 );
+
+  TEST_RR_ZEROSRC1( 35, sltu, 1, -1 );
+  TEST_RR_ZEROSRC2( 36, sltu, 0, -1 );
+  TEST_RR_ZEROSRC12( 37, sltu, 0 );
+  TEST_RR_ZERODEST( 38, sltu, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sra.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sra.S
@@ -1,0 +1,90 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sra.S
+#-----------------------------------------------------------------------------
+#
+# Test sra instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  sra, 0xffffffff80000000, 0xffffffff80000000, 0  );
+  TEST_RR_OP( 3,  sra, 0xffffffffc0000000, 0xffffffff80000000, 1  );
+  TEST_RR_OP( 4,  sra, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_OP( 5,  sra, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_OP( 6,  sra, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_RR_OP( 7,  sra, 0x000000007fffffff, 0x000000007fffffff, 0  );
+  TEST_RR_OP( 8,  sra, 0x000000003fffffff, 0x000000007fffffff, 1  );
+  TEST_RR_OP( 9,  sra, 0x0000000000ffffff, 0x000000007fffffff, 7  );
+  TEST_RR_OP( 10, sra, 0x000000000001ffff, 0x000000007fffffff, 14 );
+  TEST_RR_OP( 11, sra, 0x0000000000000000, 0x000000007fffffff, 31 );
+
+  TEST_RR_OP( 12, sra, 0xffffffff81818181, 0xffffffff81818181, 0  );
+  TEST_RR_OP( 13, sra, 0xffffffffc0c0c0c0, 0xffffffff81818181, 1  );
+  TEST_RR_OP( 14, sra, 0xffffffffff030303, 0xffffffff81818181, 7  );
+  TEST_RR_OP( 15, sra, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
+  TEST_RR_OP( 16, sra, 0xffffffffffffffff, 0xffffffff81818181, 31 );
+
+  # Verify that shifts only use bottom five bits
+
+  TEST_RR_OP( 17, sra, 0xffffffff81818181, 0xffffffff81818181, 0xffffffffffffffc0 );
+  TEST_RR_OP( 18, sra, 0xffffffffc0c0c0c0, 0xffffffff81818181, 0xffffffffffffffc1 );
+  TEST_RR_OP( 19, sra, 0xffffffffff030303, 0xffffffff81818181, 0xffffffffffffffc7 );
+  TEST_RR_OP( 20, sra, 0xfffffffffffe0606, 0xffffffff81818181, 0xffffffffffffffce );
+  TEST_RR_OP( 21, sra, 0xffffffffffffffff, 0xffffffff81818181, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 22, sra, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC2_EQ_DEST( 23, sra, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_EQ_DEST( 24, sra, 0, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 25, 0, sra, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_DEST_BYPASS( 26, 1, sra, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_DEST_BYPASS( 27, 2, sra, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+
+  TEST_RR_SRC12_BYPASS( 28, 0, 0, sra, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 29, 0, 1, sra, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 30, 0, 2, sra, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+  TEST_RR_SRC12_BYPASS( 31, 1, 0, sra, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 32, 1, 1, sra, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 33, 2, 0, sra, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+
+  TEST_RR_SRC21_BYPASS( 34, 0, 0, sra, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 35, 0, 1, sra, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 36, 0, 2, sra, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+  TEST_RR_SRC21_BYPASS( 37, 1, 0, sra, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 38, 1, 1, sra, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 39, 2, 0, sra, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+
+  TEST_RR_ZEROSRC1( 40, sra, 0, 15 );
+  TEST_RR_ZEROSRC2( 41, sra, 32, 32 );
+  TEST_RR_ZEROSRC12( 42, sra, 0 );
+  TEST_RR_ZERODEST( 43, sra, 1024, 2048 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srai.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srai.S
@@ -1,0 +1,68 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srai.S
+#-----------------------------------------------------------------------------
+#
+# Test srai instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  srai, 0xffffff8000000000, 0xffffff8000000000, 0  );
+  TEST_IMM_OP( 3,  srai, 0xffffffffc0000000, 0xffffffff80000000, 1  );
+  TEST_IMM_OP( 4,  srai, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_IMM_OP( 5,  srai, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_IMM_OP( 6,  srai, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_IMM_OP( 7,  srai, 0x000000007fffffff, 0x000000007fffffff, 0  );
+  TEST_IMM_OP( 8,  srai, 0x000000003fffffff, 0x000000007fffffff, 1  );
+  TEST_IMM_OP( 9,  srai, 0x0000000000ffffff, 0x000000007fffffff, 7  );
+  TEST_IMM_OP( 10, srai, 0x000000000001ffff, 0x000000007fffffff, 14 );
+  TEST_IMM_OP( 11, srai, 0x0000000000000000, 0x000000007fffffff, 31 );
+
+  TEST_IMM_OP( 12, srai, 0xffffffff81818181, 0xffffffff81818181, 0  );
+  TEST_IMM_OP( 13, srai, 0xffffffffc0c0c0c0, 0xffffffff81818181, 1  );
+  TEST_IMM_OP( 14, srai, 0xffffffffff030303, 0xffffffff81818181, 7  );
+  TEST_IMM_OP( 15, srai, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
+  TEST_IMM_OP( 16, srai, 0xffffffffffffffff, 0xffffffff81818181, 31 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, srai, 0xffffffffff000000, 0xffffffff80000000, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, srai, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, srai, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, srai, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, srai, 0xffffffffff000000, 0xffffffff80000000, 7 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, srai, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, srai, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, srai, 0, 4 );
+  TEST_IMM_ZERODEST( 25, srai, 33, 10 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sraiw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sraiw.S
@@ -1,0 +1,71 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sraiw.S
+#-----------------------------------------------------------------------------
+#
+# Test sraiw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  sraiw, 0xffffffff80000000, 0xffffffff80000000, 0  );
+  TEST_IMM_OP( 3,  sraiw, 0xffffffffc0000000, 0xffffffff80000000, 1  );
+  TEST_IMM_OP( 4,  sraiw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_IMM_OP( 5,  sraiw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_IMM_OP( 6,  sraiw, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_IMM_OP( 7,  sraiw, 0x000000007fffffff, 0x000000007fffffff, 0  );
+  TEST_IMM_OP( 8,  sraiw, 0x000000003fffffff, 0x000000007fffffff, 1  );
+  TEST_IMM_OP( 9,  sraiw, 0x0000000000ffffff, 0x000000007fffffff, 7  );
+  TEST_IMM_OP( 10, sraiw, 0x000000000001ffff, 0x000000007fffffff, 14 );
+  TEST_IMM_OP( 11, sraiw, 0x0000000000000000, 0x000000007fffffff, 31 );
+
+  TEST_IMM_OP( 12, sraiw, 0xffffffff81818181, 0xffffffff81818181, 0  );
+  TEST_IMM_OP( 13, sraiw, 0xffffffffc0c0c0c0, 0xffffffff81818181, 1  );
+  TEST_IMM_OP( 14, sraiw, 0xffffffffff030303, 0xffffffff81818181, 7  );
+  TEST_IMM_OP( 15, sraiw, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
+  TEST_IMM_OP( 16, sraiw, 0xffffffffffffffff, 0xffffffff81818181, 31 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, sraiw, 0xffffffffff000000, 0xffffffff80000000, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, sraiw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, sraiw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, sraiw, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, sraiw, 0xffffffffff000000, 0xffffffff80000000, 7 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, sraiw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, sraiw, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, sraiw, 0, 31 );
+  TEST_IMM_ZERODEST( 25, sraiw, 31, 28 );
+
+  TEST_IMM_OP( 26, sraiw, 0x0000000000000000, 0x00e0000000000000, 28)
+  TEST_IMM_OP( 27, sraiw, 0xffffffffff000000, 0x00000000f0000000, 4)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sraw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sraw.S
@@ -1,0 +1,90 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sraw.S
+#-----------------------------------------------------------------------------
+#
+# Test sraw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  sraw, 0xffffffff80000000, 0xffffffff80000000, 0  );
+  TEST_RR_OP( 3,  sraw, 0xffffffffc0000000, 0xffffffff80000000, 1  );
+  TEST_RR_OP( 4,  sraw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_OP( 5,  sraw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_OP( 6,  sraw, 0xffffffffffffffff, 0xffffffff80000001, 31 );
+
+  TEST_RR_OP( 7,  sraw, 0x000000007fffffff, 0x000000007fffffff, 0  );
+  TEST_RR_OP( 8,  sraw, 0x000000003fffffff, 0x000000007fffffff, 1  );
+  TEST_RR_OP( 9,  sraw, 0x0000000000ffffff, 0x000000007fffffff, 7  );
+  TEST_RR_OP( 10, sraw, 0x000000000001ffff, 0x000000007fffffff, 14 );
+  TEST_RR_OP( 11, sraw, 0x0000000000000000, 0x000000007fffffff, 31 );
+
+  TEST_RR_OP( 12, sraw, 0xffffffff81818181, 0xffffffff81818181, 0  );
+  TEST_RR_OP( 13, sraw, 0xffffffffc0c0c0c0, 0xffffffff81818181, 1  );
+  TEST_RR_OP( 14, sraw, 0xffffffffff030303, 0xffffffff81818181, 7  );
+  TEST_RR_OP( 15, sraw, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
+  TEST_RR_OP( 16, sraw, 0xffffffffffffffff, 0xffffffff81818181, 31 );
+
+  # Verify that shifts only use bottom five bits
+
+  TEST_RR_OP( 17, sraw, 0xffffffff81818181, 0xffffffff81818181, 0xffffffffffffffe0 );
+  TEST_RR_OP( 18, sraw, 0xffffffffc0c0c0c0, 0xffffffff81818181, 0xffffffffffffffe1 );
+  TEST_RR_OP( 19, sraw, 0xffffffffff030303, 0xffffffff81818181, 0xffffffffffffffe7 );
+  TEST_RR_OP( 20, sraw, 0xfffffffffffe0606, 0xffffffff81818181, 0xffffffffffffffee );
+  TEST_RR_OP( 21, sraw, 0xffffffffffffffff, 0xffffffff81818181, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 22, sraw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC2_EQ_DEST( 23, sraw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_EQ_DEST( 24, sraw, 0, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 25, 0, sraw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_DEST_BYPASS( 26, 1, sraw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_DEST_BYPASS( 27, 2, sraw, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+
+  TEST_RR_SRC12_BYPASS( 28, 0, 0, sraw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 29, 0, 1, sraw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 30, 0, 2, sraw, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+  TEST_RR_SRC12_BYPASS( 31, 1, 0, sraw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 32, 1, 1, sraw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 33, 2, 0, sraw, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+
+  TEST_RR_SRC21_BYPASS( 34, 0, 0, sraw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 35, 0, 1, sraw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 36, 0, 2, sraw, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+  TEST_RR_SRC21_BYPASS( 37, 1, 0, sraw, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 38, 1, 1, sraw, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 39, 2, 0, sraw, 0xffffffffffffffff, 0xffffffff80000000, 31 );
+
+  TEST_RR_ZEROSRC1( 40, sraw, 0, 15 );
+  TEST_RR_ZEROSRC2( 41, sraw, 32, 32 );
+  TEST_RR_ZEROSRC12( 42, sraw, 0 );
+  TEST_RR_ZERODEST( 43, sraw, 1024, 2048 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srl.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srl.S
@@ -1,0 +1,93 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srl.S
+#-----------------------------------------------------------------------------
+#
+# Test srl instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+#define TEST_SRL(n, v, a) \
+  TEST_RR_OP(n, srl, ((v) & ((1 << (__riscv_xlen-1) << 1) - 1)) >> (a), v, a)
+
+  TEST_SRL( 2,  0xffffffff80000000, 0  );
+  TEST_SRL( 3,  0xffffffff80000000, 1  );
+  TEST_SRL( 4,  0xffffffff80000000, 7  );
+  TEST_SRL( 5,  0xffffffff80000000, 14 );
+  TEST_SRL( 6,  0xffffffff80000001, 31 );
+
+  TEST_SRL( 7,  0xffffffffffffffff, 0  );
+  TEST_SRL( 8,  0xffffffffffffffff, 1  );
+  TEST_SRL( 9,  0xffffffffffffffff, 7  );
+  TEST_SRL( 10, 0xffffffffffffffff, 14 );
+  TEST_SRL( 11, 0xffffffffffffffff, 31 );
+
+  TEST_SRL( 12, 0x0000000021212121, 0  );
+  TEST_SRL( 13, 0x0000000021212121, 1  );
+  TEST_SRL( 14, 0x0000000021212121, 7  );
+  TEST_SRL( 15, 0x0000000021212121, 14 );
+  TEST_SRL( 16, 0x0000000021212121, 31 );
+
+  # Verify that shifts only use bottom five bits
+
+  TEST_RR_OP( 17, srl, 0x0000000021212121, 0x0000000021212121, 0xffffffffffffffc0 );
+  TEST_RR_OP( 18, srl, 0x0000000010909090, 0x0000000021212121, 0xffffffffffffffc1 );
+  TEST_RR_OP( 19, srl, 0x0000000000424242, 0x0000000021212121, 0xffffffffffffffc7 );
+  TEST_RR_OP( 20, srl, 0x0000000000008484, 0x0000000021212121, 0xffffffffffffffce );
+  TEST_RR_OP( 21, srl, 0x0000000000000000, 0x0000000021212121, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 22, srl, 0x01000000, 0x80000000, 7  );
+  TEST_RR_SRC2_EQ_DEST( 23, srl, 0x00020000, 0x80000000, 14 );
+  TEST_RR_SRC12_EQ_DEST( 24, srl, 0, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 25, 0, srl, 0x01000000, 0x80000000, 7  );
+  TEST_RR_DEST_BYPASS( 26, 1, srl, 0x00020000, 0x80000000, 14 );
+  TEST_RR_DEST_BYPASS( 27, 2, srl, 0x00000001, 0x80000000, 31 );
+
+  TEST_RR_SRC12_BYPASS( 28, 0, 0, srl, 0x01000000, 0x80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 29, 0, 1, srl, 0x00020000, 0x80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 30, 0, 2, srl, 0x00000001, 0x80000000, 31 );
+  TEST_RR_SRC12_BYPASS( 31, 1, 0, srl, 0x01000000, 0x80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 32, 1, 1, srl, 0x00020000, 0x80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 33, 2, 0, srl, 0x00000001, 0x80000000, 31 );
+
+  TEST_RR_SRC21_BYPASS( 34, 0, 0, srl, 0x01000000, 0x80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 35, 0, 1, srl, 0x00020000, 0x80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 36, 0, 2, srl, 0x00000001, 0x80000000, 31 );
+  TEST_RR_SRC21_BYPASS( 37, 1, 0, srl, 0x01000000, 0x80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 38, 1, 1, srl, 0x00020000, 0x80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 39, 2, 0, srl, 0x00000001, 0x80000000, 31 );
+
+  TEST_RR_ZEROSRC1( 40, srl, 0, 15 );
+  TEST_RR_ZEROSRC2( 41, srl, 32, 32 );
+  TEST_RR_ZEROSRC12( 42, srl, 0 );
+  TEST_RR_ZERODEST( 43, srl, 1024, 2048 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srli.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srli.S
@@ -1,0 +1,71 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srli.S
+#-----------------------------------------------------------------------------
+#
+# Test srli instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+#define TEST_SRL(n, v, a) \
+  TEST_IMM_OP(n, srli, ((v) & ((1 << (__riscv_xlen-1) << 1) - 1)) >> (a), v, a)
+
+  TEST_SRL( 2,  0xffffffff80000000, 0  );
+  TEST_SRL( 3,  0xffffffff80000000, 1  );
+  TEST_SRL( 4,  0xffffffff80000000, 7  );
+  TEST_SRL( 5,  0xffffffff80000000, 14 );
+  TEST_SRL( 6,  0xffffffff80000001, 31 );
+
+  TEST_SRL( 7,  0xffffffffffffffff, 0  );
+  TEST_SRL( 8,  0xffffffffffffffff, 1  );
+  TEST_SRL( 9,  0xffffffffffffffff, 7  );
+  TEST_SRL( 10, 0xffffffffffffffff, 14 );
+  TEST_SRL( 11, 0xffffffffffffffff, 31 );
+
+  TEST_SRL( 12, 0x0000000021212121, 0  );
+  TEST_SRL( 13, 0x0000000021212121, 1  );
+  TEST_SRL( 14, 0x0000000021212121, 7  );
+  TEST_SRL( 15, 0x0000000021212121, 14 );
+  TEST_SRL( 16, 0x0000000021212121, 31 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, srli, 0x01000000, 0x80000000, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, srli, 0x01000000, 0x80000000, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, srli, 0x00020000, 0x80000000, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, srli, 0x00000001, 0x80000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, srli, 0x01000000, 0x80000000, 7  );
+  TEST_IMM_SRC1_BYPASS( 22, 1, srli, 0x00020000, 0x80000000, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, srli, 0x00000001, 0x80000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, srli, 0, 4 );
+  TEST_IMM_ZERODEST( 25, srli, 33, 10 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srliw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srliw.S
@@ -1,0 +1,68 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srliw.S
+#-----------------------------------------------------------------------------
+#
+# Test srliw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  srliw, 0xffffffff80000000, 0xffffffff80000000, 0  );
+  TEST_IMM_OP( 3,  srliw, 0x0000000040000000, 0xffffffff80000000, 1  );
+  TEST_IMM_OP( 4,  srliw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_IMM_OP( 5,  srliw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_IMM_OP( 6,  srliw, 0x0000000000000001, 0xffffffff80000001, 31 );
+
+  TEST_IMM_OP( 7,  srliw, 0xffffffffffffffff, 0xffffffffffffffff, 0  );
+  TEST_IMM_OP( 8,  srliw, 0x000000007fffffff, 0xffffffffffffffff, 1  );
+  TEST_IMM_OP( 9,  srliw, 0x0000000001ffffff, 0xffffffffffffffff, 7  );
+  TEST_IMM_OP( 10, srliw, 0x000000000003ffff, 0xffffffffffffffff, 14 );
+  TEST_IMM_OP( 11, srliw, 0x0000000000000001, 0xffffffffffffffff, 31 );
+
+  TEST_IMM_OP( 12, srliw, 0x0000000021212121, 0x0000000021212121, 0  );
+  TEST_IMM_OP( 13, srliw, 0x0000000010909090, 0x0000000021212121, 1  );
+  TEST_IMM_OP( 14, srliw, 0x0000000000424242, 0x0000000021212121, 7  );
+  TEST_IMM_OP( 15, srliw, 0x0000000000008484, 0x0000000021212121, 14 );
+  TEST_IMM_OP( 16, srliw, 0x0000000000000000, 0x0000000021212121, 31 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, srliw, 0x0000000001000000, 0xffffffff80000000, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, srliw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, srliw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, srliw, 0x0000000000000001, 0xffffffff80000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, srliw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_IMM_SRC1_BYPASS( 22, 1, srliw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, srliw, 0x0000000000000001, 0xffffffff80000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, srliw, 0, 31 );
+  TEST_IMM_ZERODEST( 25, srliw, 31, 28 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srlw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-srlw.S
@@ -1,0 +1,90 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srlw.S
+#-----------------------------------------------------------------------------
+#
+# Test srlw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  srlw, 0xffffffff80000000, 0xffffffff80000000, 0  );
+  TEST_RR_OP( 3,  srlw, 0x0000000040000000, 0xffffffff80000000, 1  );
+  TEST_RR_OP( 4,  srlw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_RR_OP( 5,  srlw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_RR_OP( 6,  srlw, 0x0000000000000001, 0xffffffff80000001, 31 );
+
+  TEST_RR_OP( 7,  srlw, 0xffffffffffffffff, 0xffffffffffffffff, 0  );
+  TEST_RR_OP( 8,  srlw, 0x000000007fffffff, 0xffffffffffffffff, 1  );
+  TEST_RR_OP( 9,  srlw, 0x0000000001ffffff, 0xffffffffffffffff, 7  );
+  TEST_RR_OP( 10, srlw, 0x000000000003ffff, 0xffffffffffffffff, 14 );
+  TEST_RR_OP( 11, srlw, 0x0000000000000001, 0xffffffffffffffff, 31 );
+
+  TEST_RR_OP( 12, srlw, 0x0000000021212121, 0x0000000021212121, 0  );
+  TEST_RR_OP( 13, srlw, 0x0000000010909090, 0x0000000021212121, 1  );
+  TEST_RR_OP( 14, srlw, 0x0000000000424242, 0x0000000021212121, 7  );
+  TEST_RR_OP( 15, srlw, 0x0000000000008484, 0x0000000021212121, 14 );
+  TEST_RR_OP( 16, srlw, 0x0000000000000000, 0x0000000021212121, 31 );
+
+  # Verify that shifts only use bottom five bits
+
+  TEST_RR_OP( 17, srlw, 0x0000000021212121, 0x0000000021212121, 0xffffffffffffffe0 );
+  TEST_RR_OP( 18, srlw, 0x0000000010909090, 0x0000000021212121, 0xffffffffffffffe1 );
+  TEST_RR_OP( 19, srlw, 0x0000000000424242, 0x0000000021212121, 0xffffffffffffffe7 );
+  TEST_RR_OP( 20, srlw, 0x0000000000008484, 0x0000000021212121, 0xffffffffffffffee );
+  TEST_RR_OP( 21, srlw, 0x0000000000000000, 0x0000000021212121, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 22, srlw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC2_EQ_DEST( 23, srlw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_EQ_DEST( 24, srlw, 0, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 25, 0, srlw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_RR_DEST_BYPASS( 26, 1, srlw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_RR_DEST_BYPASS( 27, 2, srlw, 0x0000000000000001, 0xffffffff80000000, 31 );
+
+  TEST_RR_SRC12_BYPASS( 28, 0, 0, srlw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 29, 0, 1, srlw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 30, 0, 2, srlw, 0x0000000000000001, 0xffffffff80000000, 31 );
+  TEST_RR_SRC12_BYPASS( 31, 1, 0, srlw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC12_BYPASS( 32, 1, 1, srlw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC12_BYPASS( 33, 2, 0, srlw, 0x0000000000000001, 0xffffffff80000000, 31 );
+
+  TEST_RR_SRC21_BYPASS( 34, 0, 0, srlw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 35, 0, 1, srlw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 36, 0, 2, srlw, 0x0000000000000001, 0xffffffff80000000, 31 );
+  TEST_RR_SRC21_BYPASS( 37, 1, 0, srlw, 0x0000000001000000, 0xffffffff80000000, 7  );
+  TEST_RR_SRC21_BYPASS( 38, 1, 1, srlw, 0x0000000000020000, 0xffffffff80000000, 14 );
+  TEST_RR_SRC21_BYPASS( 39, 2, 0, srlw, 0x0000000000000001, 0xffffffff80000000, 31 );
+
+  TEST_RR_ZEROSRC1( 40, srlw, 0, 15 );
+  TEST_RR_ZEROSRC2( 41, srlw, 32, 32 );
+  TEST_RR_ZEROSRC12( 42, srlw, 0 );
+  TEST_RR_ZERODEST( 43, srlw, 1024, 2048 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sub.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sub.S
@@ -1,0 +1,83 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sub.S
+#-----------------------------------------------------------------------------
+#
+# Test sub instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  sub, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000 );
+  TEST_RR_OP( 3,  sub, 0x0000000000000000, 0x0000000000000001, 0x0000000000000001 );
+  TEST_RR_OP( 4,  sub, 0xfffffffffffffffc, 0x0000000000000003, 0x0000000000000007 );
+
+  TEST_RR_OP( 5,  sub, 0x0000000000008000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  sub, 0xffffffff80000000, 0xffffffff80000000, 0x0000000000000000 );
+  TEST_RR_OP( 7,  sub, 0xffffffff80008000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 8,  sub, 0xffffffffffff8001, 0x0000000000000000, 0x0000000000007fff );
+  TEST_RR_OP( 9,  sub, 0x000000007fffffff, 0x000000007fffffff, 0x0000000000000000 );
+  TEST_RR_OP( 10, sub, 0x000000007fff8000, 0x000000007fffffff, 0x0000000000007fff );
+
+  TEST_RR_OP( 11, sub, 0xffffffff7fff8001, 0xffffffff80000000, 0x0000000000007fff );
+  TEST_RR_OP( 12, sub, 0x0000000080007fff, 0x000000007fffffff, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 13, sub, 0x0000000000000001, 0x0000000000000000, 0xffffffffffffffff );
+  TEST_RR_OP( 14, sub, 0xfffffffffffffffe, 0xffffffffffffffff, 0x0000000000000001 );
+  TEST_RR_OP( 15, sub, 0x0000000000000000, 0xffffffffffffffff, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 16, sub, 2, 13, 11 );
+  TEST_RR_SRC2_EQ_DEST( 17, sub, 3, 14, 11 );
+  TEST_RR_SRC12_EQ_DEST( 18, sub, 0, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 19, 0, sub, 2, 13, 11 );
+  TEST_RR_DEST_BYPASS( 20, 1, sub, 3, 14, 11 );
+  TEST_RR_DEST_BYPASS( 21, 2, sub, 4, 15, 11 );
+
+  TEST_RR_SRC12_BYPASS( 22, 0, 0, sub, 2, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 23, 0, 1, sub, 3, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 2, sub, 4, 15, 11 );
+  TEST_RR_SRC12_BYPASS( 25, 1, 0, sub, 2, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 1, sub, 3, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 27, 2, 0, sub, 4, 15, 11 );
+
+  TEST_RR_SRC21_BYPASS( 28, 0, 0, sub, 2, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 29, 0, 1, sub, 3, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 2, sub, 4, 15, 11 );
+  TEST_RR_SRC21_BYPASS( 31, 1, 0, sub, 2, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 1, sub, 3, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 33, 2, 0, sub, 4, 15, 11 );
+
+  TEST_RR_ZEROSRC1( 34, sub, 15, -15 );
+  TEST_RR_ZEROSRC2( 35, sub, 32, 32 );
+  TEST_RR_ZEROSRC12( 36, sub, 0 );
+  TEST_RR_ZERODEST( 37, sub, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-subw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-subw.S
@@ -1,0 +1,83 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# subw.S
+#-----------------------------------------------------------------------------
+#
+# Test subw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  subw, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000 );
+  TEST_RR_OP( 3,  subw, 0x0000000000000000, 0x0000000000000001, 0x0000000000000001 );
+  TEST_RR_OP( 4,  subw, 0xfffffffffffffffc, 0x0000000000000003, 0x0000000000000007 );
+
+  TEST_RR_OP( 5,  subw, 0x0000000000008000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  subw, 0xffffffff80000000, 0xffffffff80000000, 0x0000000000000000 );
+  TEST_RR_OP( 7,  subw, 0xffffffff80008000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 8,  subw, 0xffffffffffff8001, 0x0000000000000000, 0x0000000000007fff );
+  TEST_RR_OP( 9,  subw, 0x000000007fffffff, 0x000000007fffffff, 0x0000000000000000 );
+  TEST_RR_OP( 10, subw, 0x000000007fff8000, 0x000000007fffffff, 0x0000000000007fff );
+
+  TEST_RR_OP( 11, subw, 0x000000007fff8001, 0xffffffff80000000, 0x0000000000007fff );
+  TEST_RR_OP( 12, subw, 0xffffffff80007fff, 0x000000007fffffff, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 13, subw, 0x0000000000000001, 0x0000000000000000, 0xffffffffffffffff );
+  TEST_RR_OP( 14, subw, 0xfffffffffffffffe, 0xffffffffffffffff, 0x0000000000000001 );
+  TEST_RR_OP( 15, subw, 0x0000000000000000, 0xffffffffffffffff, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 16, subw, 2, 13, 11 );
+  TEST_RR_SRC2_EQ_DEST( 17, subw, 3, 14, 11 );
+  TEST_RR_SRC12_EQ_DEST( 18, subw, 0, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 19, 0, subw, 2, 13, 11 );
+  TEST_RR_DEST_BYPASS( 20, 1, subw, 3, 14, 11 );
+  TEST_RR_DEST_BYPASS( 21, 2, subw, 4, 15, 11 );
+
+  TEST_RR_SRC12_BYPASS( 22, 0, 0, subw, 2, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 23, 0, 1, subw, 3, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 2, subw, 4, 15, 11 );
+  TEST_RR_SRC12_BYPASS( 25, 1, 0, subw, 2, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 1, subw, 3, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 27, 2, 0, subw, 4, 15, 11 );
+
+  TEST_RR_SRC21_BYPASS( 28, 0, 0, subw, 2, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 29, 0, 1, subw, 3, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 2, subw, 4, 15, 11 );
+  TEST_RR_SRC21_BYPASS( 31, 1, 0, subw, 2, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 1, subw, 3, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 33, 2, 0, subw, 4, 15, 11 );
+
+  TEST_RR_ZEROSRC1( 34, subw, 15, -15 );
+  TEST_RR_ZEROSRC2( 35, subw, 32, 32 );
+  TEST_RR_ZEROSRC12( 36, subw, 0 );
+  TEST_RR_ZERODEST( 37, subw, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-sw.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sw.S
+#-----------------------------------------------------------------------------
+#
+# Test sw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, lw, sw, 0x0000000000aa00aa, 0,  tdat );
+  TEST_ST_OP( 3, lw, sw, 0xffffffffaa00aa00, 4,  tdat );
+  TEST_ST_OP( 4, lw, sw, 0x000000000aa00aa0, 8,  tdat );
+  TEST_ST_OP( 5, lw, sw, 0xffffffffa00aa00a, 12, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, lw, sw, 0x0000000000aa00aa, -12, tdat8 );
+  TEST_ST_OP( 7, lw, sw, 0xffffffffaa00aa00, -8,  tdat8 );
+  TEST_ST_OP( 8, lw, sw, 0x000000000aa00aa0, -4,  tdat8 );
+  TEST_ST_OP( 9, lw, sw, 0xffffffffa00aa00a, 0,   tdat8 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x12345678, \
+    la  x1, tdat9; \
+    li  x2, 0x12345678; \
+    addi x4, x1, -32; \
+    sw x2, 32(x4); \
+    lw x5, 0(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x58213098, \
+    la  x1, tdat9; \
+    li  x2, 0x58213098; \
+    addi x1, x1, -3; \
+    sw x2, 7(x1); \
+    la  x4, tdat10; \
+    lw x5, 0(x4); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_ST_SRC12_BYPASS( 12, 0, 0, lw, sw, 0xffffffffaabbccdd, 0,  tdat );
+  TEST_ST_SRC12_BYPASS( 13, 0, 1, lw, sw, 0xffffffffdaabbccd, 4,  tdat );
+  TEST_ST_SRC12_BYPASS( 14, 0, 2, lw, sw, 0xffffffffddaabbcc, 8,  tdat );
+  TEST_ST_SRC12_BYPASS( 15, 1, 0, lw, sw, 0xffffffffcddaabbc, 12, tdat );
+  TEST_ST_SRC12_BYPASS( 16, 1, 1, lw, sw, 0xffffffffccddaabb, 16, tdat );
+  TEST_ST_SRC12_BYPASS( 17, 2, 0, lw, sw, 0xffffffffbccddaab, 20, tdat );
+
+  TEST_ST_SRC21_BYPASS( 18, 0, 0, lw, sw, 0x00112233, 0,  tdat );
+  TEST_ST_SRC21_BYPASS( 19, 0, 1, lw, sw, 0x30011223, 4,  tdat );
+  TEST_ST_SRC21_BYPASS( 20, 0, 2, lw, sw, 0x33001122, 8,  tdat );
+  TEST_ST_SRC21_BYPASS( 21, 1, 0, lw, sw, 0x23300112, 12, tdat );
+  TEST_ST_SRC21_BYPASS( 22, 1, 1, lw, sw, 0x22330011, 16, tdat );
+  TEST_ST_SRC21_BYPASS( 23, 2, 0, lw, sw, 0x12233001, 20, tdat );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .word 0xdeadbeef
+tdat2:  .word 0xdeadbeef
+tdat3:  .word 0xdeadbeef
+tdat4:  .word 0xdeadbeef
+tdat5:  .word 0xdeadbeef
+tdat6:  .word 0xdeadbeef
+tdat7:  .word 0xdeadbeef
+tdat8:  .word 0xdeadbeef
+tdat9:  .word 0xdeadbeef
+tdat10: .word 0xdeadbeef
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-xor.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-xor.S
@@ -1,0 +1,69 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# xor.S
+#-----------------------------------------------------------------------------
+#
+# Test xor instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Logical tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_OP( 3, xor, 0xff00ff00, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_OP( 4, xor, 0x0ff00ff0, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_OP( 5, xor, 0x00ff00ff, 0xf00ff00f, 0xf0f0f0f0 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 6, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC2_EQ_DEST( 7, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_EQ_DEST( 8, xor, 0x00000000, 0xff00ff00 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 9,  0, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_DEST_BYPASS( 10, 1, xor, 0xff00ff00, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_DEST_BYPASS( 11, 2, xor, 0x0ff00ff0, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_SRC12_BYPASS( 12, 0, 0, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 13, 0, 1, xor, 0xff00ff00, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC12_BYPASS( 14, 0, 2, xor, 0x0ff00ff0, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 15, 1, 0, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC12_BYPASS( 16, 1, 1, xor, 0xff00ff00, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC12_BYPASS( 17, 2, 0, xor, 0x0ff00ff0, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_SRC21_BYPASS( 18, 0, 0, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 19, 0, 1, xor, 0xff00ff00, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC21_BYPASS( 20, 0, 2, xor, 0x0ff00ff0, 0x00ff00ff, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 21, 1, 0, xor, 0xf00ff00f, 0xff00ff00, 0x0f0f0f0f );
+  TEST_RR_SRC21_BYPASS( 22, 1, 1, xor, 0xff00ff00, 0x0ff00ff0, 0xf0f0f0f0 );
+  TEST_RR_SRC21_BYPASS( 23, 2, 0, xor, 0x0ff00ff0, 0x00ff00ff, 0x0f0f0f0f );
+
+  TEST_RR_ZEROSRC1( 24, xor, 0xff00ff00, 0xff00ff00 );
+  TEST_RR_ZEROSRC2( 25, xor, 0x00ff00ff, 0x00ff00ff );
+  TEST_RR_ZEROSRC12( 26, xor, 0 );
+  TEST_RR_ZERODEST( 27, xor, 0x11111111, 0x22222222 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-xori.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64ui-p-xori.S
@@ -1,0 +1,55 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# xori.S
+#-----------------------------------------------------------------------------
+#
+# Test xori instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Logical tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2, xori, 0xffffffffff00f00f, 0x0000000000ff0f00, 0xf0f );
+  TEST_IMM_OP( 3, xori, 0x000000000ff00f00, 0x000000000ff00ff0, 0x0f0 );
+  TEST_IMM_OP( 4, xori, 0x0000000000ff0ff0, 0x0000000000ff08ff, 0x70f );
+  TEST_IMM_OP( 5, xori, 0xfffffffff00ff0ff, 0xfffffffff00ff00f, 0x0f0 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 6, xori, 0xffffffffff00f00f, 0xffffffffff00f700, 0x70f );
+
+   #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 7,  0, xori, 0x000000000ff00f00, 0x000000000ff00ff0, 0x0f0 );
+  TEST_IMM_DEST_BYPASS( 8,  1, xori, 0x0000000000ff0ff0, 0x0000000000ff08ff, 0x70f );
+  TEST_IMM_DEST_BYPASS( 9,  2, xori, 0xfffffffff00ff0ff, 0xfffffffff00ff00f, 0x0f0 );
+
+  TEST_IMM_SRC1_BYPASS( 10, 0, xori, 0x000000000ff00f00, 0x000000000ff00ff0, 0x0f0 );
+  TEST_IMM_SRC1_BYPASS( 11, 1, xori, 0x0000000000ff0ff0, 0x0000000000ff0fff, 0x00f );
+  TEST_IMM_SRC1_BYPASS( 12, 2, xori, 0xfffffffff00ff0ff, 0xfffffffff00ff00f, 0x0f0 );
+
+  TEST_IMM_ZEROSRC1( 13, xori, 0x0f0, 0x0f0 );
+  TEST_IMM_ZERODEST( 14, xori, 0x00ff00ff, 0x70f );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-div.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-div.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# div.S
+#-----------------------------------------------------------------------------
+#
+# Test div instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, div,  3,  20,   6 );
+  TEST_RR_OP( 3, div, -3, -20,   6 );
+  TEST_RR_OP( 4, div, -3,  20,  -6 );
+  TEST_RR_OP( 5, div,  3, -20,  -6 );
+
+  TEST_RR_OP( 6, div, -1<<63, -1<<63,  1 );
+  TEST_RR_OP( 7, div, -1<<63, -1<<63, -1 );
+
+  TEST_RR_OP( 8, div, -1, -1<<63, 0 );
+  TEST_RR_OP( 9, div, -1,      1, 0 );
+  TEST_RR_OP(10, div, -1,      0, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-divu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-divu.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# divu.S
+#-----------------------------------------------------------------------------
+#
+# Test divu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, divu,                   3,  20,   6 );
+  TEST_RR_OP( 3, divu, 3074457345618258599, -20,   6 );
+  TEST_RR_OP( 4, divu,                   0,  20,  -6 );
+  TEST_RR_OP( 5, divu,                   0, -20,  -6 );
+
+  TEST_RR_OP( 6, divu, -1<<63, -1<<63,  1 );
+  TEST_RR_OP( 7, divu,     0,  -1<<63, -1 );
+
+  TEST_RR_OP( 8, divu, -1, -1<<63, 0 );
+  TEST_RR_OP( 9, divu, -1,      1, 0 );
+  TEST_RR_OP(10, divu, -1,      0, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-divuw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-divuw.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# divuw.S
+#-----------------------------------------------------------------------------
+#
+# Test divuw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, divuw,         3,  20,   6 );
+  TEST_RR_OP( 3, divuw, 715827879, -20 << 32 >> 32,   6 );
+  TEST_RR_OP( 4, divuw,         0,  20,  -6 );
+  TEST_RR_OP( 5, divuw,         0, -20,  -6 );
+
+  TEST_RR_OP( 6, divuw, -1<<31, -1<<31,  1 );
+  TEST_RR_OP( 7, divuw, 0,      -1<<31, -1 );
+
+  TEST_RR_OP( 8, divuw, -1, -1<<31, 0 );
+  TEST_RR_OP( 9, divuw, -1,      1, 0 );
+  TEST_RR_OP(10, divuw, -1,      0, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-divw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-divw.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# divw.S
+#-----------------------------------------------------------------------------
+#
+# Test divw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, divw,  3,  20,   6 );
+  TEST_RR_OP( 3, divw, -3, -20,   6 );
+  TEST_RR_OP( 4, divw, -3,  20,  -6 );
+  TEST_RR_OP( 5, divw,  3, -20,  -6 );
+
+  TEST_RR_OP( 6, divw, -1<<31, -1<<31,  1 );
+  TEST_RR_OP( 7, divw, -1<<31, -1<<31, -1 );
+
+  TEST_RR_OP( 8, divw, -1, -1<<31, 0 );
+  TEST_RR_OP( 9, divw, -1,      1, 0 );
+  TEST_RR_OP(10, divw, -1,      0, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mul.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mul.S
@@ -1,0 +1,78 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# mul.S
+#-----------------------------------------------------------------------------
+#
+# Test mul instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP(32,  mul, 0x0000000000001200, 0x0000000000007e00, 0x6db6db6db6db6db7 );
+  TEST_RR_OP(33,  mul, 0x0000000000001240, 0x0000000000007fc0, 0x6db6db6db6db6db7 );
+
+  TEST_RR_OP( 2,  mul, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  mul, 0x00000001, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  mul, 0x00000015, 0x00000003, 0x00000007 );
+
+  TEST_RR_OP( 5,  mul, 0x0000000000000000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  mul, 0x0000000000000000, 0xffffffff80000000, 0x00000000 );
+  TEST_RR_OP( 7,  mul, 0x0000400000000000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP(30,  mul, 0x000000000000ff7f, 0xaaaaaaaaaaaaaaab, 0x000000000002fe7d );
+  TEST_RR_OP(31,  mul, 0x000000000000ff7f, 0x000000000002fe7d, 0xaaaaaaaaaaaaaaab );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 8, mul, 143, 13, 11 );
+  TEST_RR_SRC2_EQ_DEST( 9, mul, 154, 14, 11 );
+  TEST_RR_SRC12_EQ_DEST( 10, mul, 169, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 11, 0, mul, 143, 13, 11 );
+  TEST_RR_DEST_BYPASS( 12, 1, mul, 154, 14, 11 );
+  TEST_RR_DEST_BYPASS( 13, 2, mul, 165, 15, 11 );
+
+  TEST_RR_SRC12_BYPASS( 14, 0, 0, mul, 143, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 15, 0, 1, mul, 154, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 16, 0, 2, mul, 165, 15, 11 );
+  TEST_RR_SRC12_BYPASS( 17, 1, 0, mul, 143, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 18, 1, 1, mul, 154, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 19, 2, 0, mul, 165, 15, 11 );
+
+  TEST_RR_SRC21_BYPASS( 20, 0, 0, mul, 143, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 21, 0, 1, mul, 154, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 22, 0, 2, mul, 165, 15, 11 );
+  TEST_RR_SRC21_BYPASS( 23, 1, 0, mul, 143, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 24, 1, 1, mul, 154, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 25, 2, 0, mul, 165, 15, 11 );
+
+  TEST_RR_ZEROSRC1( 26, mul, 0, 31 );
+  TEST_RR_ZEROSRC2( 27, mul, 0, 32 );
+  TEST_RR_ZEROSRC12( 28, mul, 0 );
+  TEST_RR_ZERODEST( 29, mul, 33, 34 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulh.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulh.S
@@ -1,0 +1,72 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# mulh.S
+#-----------------------------------------------------------------------------
+#
+# Test mulh instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  mulh, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  mulh, 0x00000000, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  mulh, 0x00000000, 0x00000003, 0x00000007 );
+
+  TEST_RR_OP( 5,  mulh, 0x0000000000000000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  mulh, 0x0000000000000000, 0xffffffff80000000, 0x00000000 );
+  TEST_RR_OP( 7,  mulh, 0x0000000000000000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 8, mulh, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC2_EQ_DEST( 9, mulh, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_EQ_DEST( 10, mulh, 169, 13<<32 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 11, 0, mulh, 143, 13<<32, 11<<32 );
+  TEST_RR_DEST_BYPASS( 12, 1, mulh, 154, 14<<32, 11<<32 );
+  TEST_RR_DEST_BYPASS( 13, 2, mulh, 165, 15<<32, 11<<32 );
+
+  TEST_RR_SRC12_BYPASS( 14, 0, 0, mulh, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 15, 0, 1, mulh, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 16, 0, 2, mulh, 165, 15<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 17, 1, 0, mulh, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 18, 1, 1, mulh, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 19, 2, 0, mulh, 165, 15<<32, 11<<32 );
+
+  TEST_RR_SRC21_BYPASS( 20, 0, 0, mulh, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 21, 0, 1, mulh, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 22, 0, 2, mulh, 165, 15<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 23, 1, 0, mulh, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 24, 1, 1, mulh, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 25, 2, 0, mulh, 165, 15<<32, 11<<32 );
+
+  TEST_RR_ZEROSRC1( 26, mulh, 0, 31<<32 );
+  TEST_RR_ZEROSRC2( 27, mulh, 0, 32<<32 );
+  TEST_RR_ZEROSRC12( 28, mulh, 0 );
+  TEST_RR_ZERODEST( 29, mulh, 33<<32, 34<<32 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulhsu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulhsu.S
@@ -1,0 +1,72 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# mulhsu.S
+#-----------------------------------------------------------------------------
+#
+# Test mulhsu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  mulhsu, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  mulhsu, 0x00000000, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  mulhsu, 0x00000000, 0x00000003, 0x00000007 );
+
+  TEST_RR_OP( 5,  mulhsu, 0x0000000000000000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  mulhsu, 0x0000000000000000, 0xffffffff80000000, 0x00000000 );
+  TEST_RR_OP( 7,  mulhsu, 0xffffffff80000000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 8, mulhsu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC2_EQ_DEST( 9, mulhsu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_EQ_DEST( 10, mulhsu, 169, 13<<32 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 11, 0, mulhsu, 143, 13<<32, 11<<32 );
+  TEST_RR_DEST_BYPASS( 12, 1, mulhsu, 154, 14<<32, 11<<32 );
+  TEST_RR_DEST_BYPASS( 13, 2, mulhsu, 165, 15<<32, 11<<32 );
+
+  TEST_RR_SRC12_BYPASS( 14, 0, 0, mulhsu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 15, 0, 1, mulhsu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 16, 0, 2, mulhsu, 165, 15<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 17, 1, 0, mulhsu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 18, 1, 1, mulhsu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 19, 2, 0, mulhsu, 165, 15<<32, 11<<32 );
+
+  TEST_RR_SRC21_BYPASS( 20, 0, 0, mulhsu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 21, 0, 1, mulhsu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 22, 0, 2, mulhsu, 165, 15<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 23, 1, 0, mulhsu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 24, 1, 1, mulhsu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 25, 2, 0, mulhsu, 165, 15<<32, 11<<32 );
+
+  TEST_RR_ZEROSRC1( 26, mulhsu, 0, 31<<32 );
+  TEST_RR_ZEROSRC2( 27, mulhsu, 0, 32<<32 );
+  TEST_RR_ZEROSRC12( 28, mulhsu, 0 );
+  TEST_RR_ZERODEST( 29, mulhsu, 33<<32, 34<<32 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulhu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulhu.S
@@ -1,0 +1,75 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# mulhu.S
+#-----------------------------------------------------------------------------
+#
+# Test mulhu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  mulhu, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  mulhu, 0x00000000, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  mulhu, 0x00000000, 0x00000003, 0x00000007 );
+
+  TEST_RR_OP( 5,  mulhu, 0x0000000000000000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  mulhu, 0x0000000000000000, 0xffffffff80000000, 0x00000000 );
+  TEST_RR_OP( 7,  mulhu, 0xffffffff7fff8000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP(30,  mulhu, 0x000000000001fefe, 0xaaaaaaaaaaaaaaab, 0x000000000002fe7d );
+  TEST_RR_OP(31,  mulhu, 0x000000000001fefe, 0x000000000002fe7d, 0xaaaaaaaaaaaaaaab );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 8, mulhu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC2_EQ_DEST( 9, mulhu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_EQ_DEST( 10, mulhu, 169, 13<<32 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 11, 0, mulhu, 143, 13<<32, 11<<32 );
+  TEST_RR_DEST_BYPASS( 12, 1, mulhu, 154, 14<<32, 11<<32 );
+  TEST_RR_DEST_BYPASS( 13, 2, mulhu, 165, 15<<32, 11<<32 );
+
+  TEST_RR_SRC12_BYPASS( 14, 0, 0, mulhu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 15, 0, 1, mulhu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 16, 0, 2, mulhu, 165, 15<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 17, 1, 0, mulhu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 18, 1, 1, mulhu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC12_BYPASS( 19, 2, 0, mulhu, 165, 15<<32, 11<<32 );
+
+  TEST_RR_SRC21_BYPASS( 20, 0, 0, mulhu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 21, 0, 1, mulhu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 22, 0, 2, mulhu, 165, 15<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 23, 1, 0, mulhu, 143, 13<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 24, 1, 1, mulhu, 154, 14<<32, 11<<32 );
+  TEST_RR_SRC21_BYPASS( 25, 2, 0, mulhu, 165, 15<<32, 11<<32 );
+
+  TEST_RR_ZEROSRC1( 26, mulhu, 0, 31<<32 );
+  TEST_RR_ZEROSRC2( 27, mulhu, 0, 32<<32 );
+  TEST_RR_ZEROSRC12( 28, mulhu, 0 );
+  TEST_RR_ZERODEST( 29, mulhu, 33<<32, 34<<32 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-mulw.S
@@ -1,0 +1,72 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# mulw.S
+#-----------------------------------------------------------------------------
+#
+# Test mulw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  mulw, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  mulw, 0x00000001, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  mulw, 0x00000015, 0x00000003, 0x00000007 );
+
+  TEST_RR_OP( 5,  mulw, 0x0000000000000000, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 6,  mulw, 0x0000000000000000, 0xffffffff80000000, 0x00000000 );
+  TEST_RR_OP( 7,  mulw, 0x0000000000000000, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 8, mulw, 143, 13, 11 );
+  TEST_RR_SRC2_EQ_DEST( 9, mulw, 154, 14, 11 );
+  TEST_RR_SRC12_EQ_DEST( 10, mulw, 169, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 11, 0, mulw, 143, 13, 11 );
+  TEST_RR_DEST_BYPASS( 12, 1, mulw, 154, 14, 11 );
+  TEST_RR_DEST_BYPASS( 13, 2, mulw, 165, 15, 11 );
+
+  TEST_RR_SRC12_BYPASS( 14, 0, 0, mulw, 143, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 15, 0, 1, mulw, 154, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 16, 0, 2, mulw, 165, 15, 11 );
+  TEST_RR_SRC12_BYPASS( 17, 1, 0, mulw, 143, 13, 11 );
+  TEST_RR_SRC12_BYPASS( 18, 1, 1, mulw, 154, 14, 11 );
+  TEST_RR_SRC12_BYPASS( 19, 2, 0, mulw, 165, 15, 11 );
+
+  TEST_RR_SRC21_BYPASS( 20, 0, 0, mulw, 143, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 21, 0, 1, mulw, 154, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 22, 0, 2, mulw, 165, 15, 11 );
+  TEST_RR_SRC21_BYPASS( 23, 1, 0, mulw, 143, 13, 11 );
+  TEST_RR_SRC21_BYPASS( 24, 1, 1, mulw, 154, 14, 11 );
+  TEST_RR_SRC21_BYPASS( 25, 2, 0, mulw, 165, 15, 11 );
+
+  TEST_RR_ZEROSRC1( 26, mulw, 0, 31 );
+  TEST_RR_ZEROSRC2( 27, mulw, 0, 32 );
+  TEST_RR_ZEROSRC12( 28, mulw, 0 );
+  TEST_RR_ZERODEST( 29, mulw, 33, 34 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-rem.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-rem.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# rem.S
+#-----------------------------------------------------------------------------
+#
+# Test rem instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, rem,  2,  20,   6 );
+  TEST_RR_OP( 3, rem, -2, -20,   6 );
+  TEST_RR_OP( 4, rem,  2,  20,  -6 );
+  TEST_RR_OP( 5, rem, -2, -20,  -6 );
+
+  TEST_RR_OP( 6, rem,  0, -1<<63,  1 );
+  TEST_RR_OP( 7, rem,  0, -1<<63, -1 );
+
+  TEST_RR_OP( 8, rem, -1<<63, -1<<63, 0 );
+  TEST_RR_OP( 9, rem,      1,      1, 0 );
+  TEST_RR_OP(10, rem,      0,      0, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-remu.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-remu.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# remu.S
+#-----------------------------------------------------------------------------
+#
+# Test remu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, remu,   2,  20,   6 );
+  TEST_RR_OP( 3, remu,   2, -20,   6 );
+  TEST_RR_OP( 4, remu,  20,  20,  -6 );
+  TEST_RR_OP( 5, remu, -20, -20,  -6 );
+
+  TEST_RR_OP( 6, remu,      0, -1<<63,  1 );
+  TEST_RR_OP( 7, remu, -1<<63, -1<<63, -1 );
+
+  TEST_RR_OP( 8, remu, -1<<63, -1<<63, 0 );
+  TEST_RR_OP( 9, remu,      1,      1, 0 );
+  TEST_RR_OP(10, remu,      0,      0, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-remuw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-remuw.S
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# remuw.S
+#-----------------------------------------------------------------------------
+#
+# Test remuw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, remuw,   2,  20,   6 );
+  TEST_RR_OP( 3, remuw,   2, -20,   6 );
+  TEST_RR_OP( 4, remuw,  20,  20,  -6 );
+  TEST_RR_OP( 5, remuw, -20, -20,  -6 );
+
+  TEST_RR_OP( 6, remuw,      0, -1<<31,  1 );
+  TEST_RR_OP( 7, remuw, -1<<31, -1<<31, -1 );
+
+  TEST_RR_OP( 8, remuw, -1<<31, -1<<31, 0 );
+  TEST_RR_OP( 9, remuw,      1,      1, 0 );
+  TEST_RR_OP(10, remuw,      0,      0, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-remw.S
+++ b/piton/verif/diag/assembly/riscv/rv64/rv64/rv64um-p-remw.S
@@ -1,0 +1,42 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# remw.S
+#-----------------------------------------------------------------------------
+#
+# Test remw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2, remw,  2,  20,   6 );
+  TEST_RR_OP( 3, remw, -2, -20,   6 );
+  TEST_RR_OP( 4, remw,  2,  20,  -6 );
+  TEST_RR_OP( 5, remw, -2, -20,  -6 );
+
+  TEST_RR_OP( 6, remw,  0, -1<<31,  1 );
+  TEST_RR_OP( 7, remw,  0, -1<<31, -1 );
+
+  TEST_RR_OP( 8, remw, -1<<31, -1<<31, 0 );
+  TEST_RR_OP( 9, remw,      1,      1, 0 );
+  TEST_RR_OP(10, remw,      0,      0, 0 );
+  TEST_RR_OP(11, remw, 0xfffffffffffff897,0xfffffffffffff897, 0 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END


### PR DESCRIPTION
I have slightly adjusted some FP testbenches to pass some simulation cases.

Passed:
rv64ud-p-fadd.S
rv64ud-p-fcmp.S
rv64ud-p-fcvt.S 		(partially)
rv64ud-p-fcvt_w.S 	        (partially)
rv64ud-p-fmin.S
rv64ud-p-structural.S

rv64uf-p-fcmp.S 		(partially)
rv64uf-p-fcvt.S 		(partially)
rv64uf-p-fcvt_w.S 	        (partially)
rv64uf-p-ldst.S

Not passed or unsupported:
rv64ud-p-fclass.S 	        (unsupported)
rv64ud-p-fdiv.S 		(not passed)
rv64ud-p-fmadd.S 		(unsupported)
rv64ud-p-ldst.S 		(not passed)
rv64ud-p-move.S 		(unsupported)
rv64ud-p-recoding.S 	(unsupported)

rv64uf-p-fadd.S 		(not passed)
rv64uf-p-fclass.S 	        (unsupported)
rv64uf-p-fdiv.S 		(not passed)
rv64uf-p-fmadd.S 		(unsupported)
rv64uf-p-fmin.S 		(not passed)
rv64uf-p-move.S 		(unsupported)
rv64uf-p-recoding.S 	(unsupported)